### PR TITLE
More basic `<Tweet />` component without authentication

### DIFF
--- a/.changeset/rare-geese-cover.md
+++ b/.changeset/rare-geese-cover.md
@@ -1,0 +1,22 @@
+---
+"@astro-community/astro-embed-twitter": minor
+---
+
+Switch to more basic Twitter component that does not require authentication
+
+**⚠️ BREAKING CHANGE** Due to upheaval at Twitter, the `<Tweet />` component is no longer able to fetch detailed information from Twitter’s API, limiting what a static embed can easily do.
+
+Key differences:
+
+- The `<Tweet />` component must now receive a full URL to a tweet, not just an ID. You will need to update these if you have any:
+
+   ```diff
+   - <Tweet id="1511750228428435457" />
+   + <Tweet id="https://twitter.com/astrodotbuild/status/1511750228428435457" />
+   ```
+
+- The rendered component is more minimal: no avatar for the tweet author; no header containing author name and handle; images and video are not expanded, only showing as links
+
+- The CSS class name on the resulting HTML is now `twitter-tweet` instead of `tweet-card` and none of the internal class names like `tweet-author`, `tweet-header` etc. are available. If you set any custom CSS to control appearance, this will likely need updating.
+
+- Authentication is no longer required. If you previously configured a `SECRET_TWITTER_TOKEN` environment variable, you can safely remove it from your project.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,3 @@ jobs:
 
       - name: Test
         run: npm run test:ci
-        env:
-          SECRET_TWITTER_TOKEN: ${{ secrets.SECRET_TWITTER_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,16 +28,6 @@ All commands are run from the root of the project, from a terminal:
 
 You can run unit tests by running `npm t` in a terminal or run `npm start` to start a dev server for the demo project.
 
-Because the `<Tweet />` component requires a Twitter API token, these tests will fail if you don’t add a bearer token to this repo.
-
-1. Create a new file at `demo/.env`
-
-2. Add your API token:
-
-   ```
-   SECRET_TWITTER_TOKEN=bearer-token-for-the-twitter-api
-   ```
-
 ## ✨ Want to contribute?
 
 This is an Astro Community project. That means YOU!

--- a/demo/src/pages/index.astro
+++ b/demo/src/pages/index.astro
@@ -3,6 +3,7 @@ import Base from '../layouts/Base.astro';
 ---
 
 <Base>
+	<h2>Components</h2>
 	<ul>
 		<li>
 			<a href="/twitter"><code>&lt;Tweet/&gt;</code> component examples</a>
@@ -13,11 +14,17 @@ import Base from '../layouts/Base.astro';
 		<li>
 			<a href="/youtube"><code>&lt;YouTube/&gt;</code> component examples</a>
 		</li>
+	</ul>
+	<h2>Other examples</h2>
+	<ul>
 		<li>
 			<a href="/markdown">Components in MDX examples</a>
 		</li>
 		<li>
 			<a href="/integration">MDX integration examples</a>
+		</li>
+		<li>
+			<a href="/twitter-with-js"><code>&lt;Tweet/&gt;</code> with JavaScript</a>
 		</li>
 	</ul>
 </Base>

--- a/demo/src/pages/markdown.mdx
+++ b/demo/src/pages/markdown.mdx
@@ -13,12 +13,12 @@ setup: |
   import { Tweet, YouTube } from 'astro-embed';
 ---
 
-<Tweet id="1511750228428435457" />
+<Tweet id="https://twitter.com/astrodotbuild/status/1511750228428435457" />
 ```
 
 ## `<Tweet />`
 
-<Tweet id="1511750228428435457" />
+<Tweet id="https://twitter.com/astrodotbuild/status/1511750228428435457" />
 
 ## `<YouTube />`
 

--- a/demo/src/pages/twitter-with-js.astro
+++ b/demo/src/pages/twitter-with-js.astro
@@ -4,6 +4,13 @@ import Base from '../layouts/Base.astro';
 ---
 
 <Base title="Twitter component examples">
+	<p>
+		These tweets use the same component code as the <a href="/twitter"
+			>main Twitter example</a
+		>, but also loads Twitter’s widget JavaScript to convert them to interactive
+		iframes:
+	</p>
+	<pre><code set:text={'<script async src="https://platform.twitter.com/widgets.js"></script>'} /></pre>
 	<Component.Tweet
 		id="https://twitter.com/astrodotbuild/status/1511750228428435457"
 	/>
@@ -17,6 +24,8 @@ import Base from '../layouts/Base.astro';
 	<Component.Tweet
 		id="https://twitter.com/astrodotbuild/status/1402352777020395521"
 	/>
+
+	<script async src="https://platform.twitter.com/widgets.js"></script>
 </Base>
 
 <style>

--- a/packages/astro-embed-twitter/README.md
+++ b/packages/astro-embed-twitter/README.md
@@ -8,44 +8,11 @@ This package contains a component for embedding tweets in Astro projects.
 npm i @astro-community/astro-embed-twitter
 ```
 
-### Authentication
-
-The `<Tweet />` component uses the Twitter API v2 to download tweet data and generate static HTML. This requires a “bearer token” for the Twitter API. You can sign up in [Twitter’s Developer Portal](https://developer.twitter.com/) to get one of these.
-
-Once you have your bearer token, add it to your local or build environment as a variable named `SECRET_TWITTER_TOKEN`.
-
-#### Local development
-
-If you’re building or developing your site locally, create a `.env` file in the root of your Astro project containing your token:
-
-```
-SECRET_TWITTER_TOKEN=bearer-token-for-the-twitter-api
-```
-
-> **Warning**
-> Don’t commit this `.env` file! Your bearer token is top secret.
-
-#### Cloud deployments/CI
-
-Different deployment platforms let you set environment variables in different ways. For example, here are the [Netlify](https://docs.netlify.com/configure-builds/environment-variables/), [Vercel](https://vercel.com/docs/concepts/projects/environment-variables), and [GitHub Actions](https://docs.github.com/en/github-ae@latest/actions/learn-github-actions/environment-variables) environment variable docs.
-
-Whatever your platform, make sure you set your bearer token as the value of a `SECRET_TWITTER_TOKEN` environment variable.
-
 ## Usage
 
-### `<Tweet id={tweetIdOrUrl} />`
+### `<Tweet id={tweetUrl} />`
 
-The **Tweet** component generates a static Twitter card for a single Tweet.
-
-```astro
----
-import { Tweet } from '@astro-community/astro-embed-twitter';
----
-
-<Tweet id="1511750228428435457" />
-```
-
-It also supports passing a full URL instead of just the ID.
+The **Tweet** component generates a static Twitter card for a single Tweet using [Twitter’s oEmbed API](https://developer.twitter.com/en/docs/twitter-for-websites/oembed-api).
 
 ```astro
 ---
@@ -55,26 +22,33 @@ import { Tweet } from '@astro-community/astro-embed-twitter';
 <Tweet id="https://twitter.com/astrodotbuild/status/1511750228428435457" />
 ```
 
+### Loading Twitter’s JavaScript
+
+By design, this is a minimal component and loads zero JavaScript, only rendering some static HTML content.
+However, this HTML is compatible with Twitter’s widget system.
+Loading Twitter‘s large bundle of widget JavaScript will convert each `<Tweet />` into an interactive embed.
+
+You can do this by including a `<script>` tag in your Astro layout file:
+
+```html
+<script async src="https://platform.twitter.com/widgets.js"></script>
+```
+
 ### Styling
 
 By default the card has minimal styling, which should adapt to your site’s font settings etc.
 
-You can customise it by targeting any of the `.tweet-` classes, for example:
+You can customise it by targeting the `.twitter-tweet` class, for example:
 
 ```css
-.tweet-card {
+.twitter-tweet {
   background: floralwhite;
   font-family: sans-serif;
   border: 0;
 }
 
-.tweet-card a {
+.twitter-tweet a {
   color: purple;
   font-weight: bold;
-}
-
-.tweet-author-name {
-  font-family: cursive;
-  font-size: 1.5em;
 }
 ```

--- a/packages/astro-embed-twitter/Tweet.astro
+++ b/packages/astro-embed-twitter/Tweet.astro
@@ -1,209 +1,58 @@
 ---
-import { Client } from 'twitter-api-sdk';
-import type { components } from 'twitter-api-sdk/dist/types';
-import urlMatcher from './matcher';
 import './Tweet.css';
-
-if (!import.meta.env.SECRET_TWITTER_TOKEN) {
-	throw new Error(
-		`Required environment variable SECRET_TWITTER_TOKEN not found.
-Not sure how to set an environment variable?
-See https://docs.astro.build/en/guides/environment-variables/#setting-environment-variables`
-	);
-}
 
 export interface Props {
 	id: string;
 }
-
-/*
-Based on...
-- https://github.com/hugomd/blog/blob/6ad96b24117255c2a9912c566ffd081bd9bbd6f1/layouts/shortcodes/statictweet.html
-- https://hugo.md/post/update-rendering-static-tweets/
-- https://github.com/KyleMit/eleventy-plugin-embed-tweet
-- https://github.com/rebelchris/astro-static-tweet/blob/master/StaticTweet.astro
-- https://www.brycewray.com/posts/2022/04/static-tweets-astro/
-*/
-
-const { id } = Astro.props as Props;
-
-const idRegExp = /^\d+$/;
-function extractID(idOrUrl: string) {
-	if (idRegExp.test(idOrUrl)) return idOrUrl;
-	return urlMatcher(idOrUrl);
-}
+const { id } = Astro.props;
 
 async function fetchTweet(id: string) {
 	try {
-		const client = new Client(import.meta.env.SECRET_TWITTER_TOKEN);
-		return await client.tweets.findTweetById(id, {
-			'tweet.fields': [
-				'attachments',
-				'author_id',
-				'text',
-				'entities',
-				'created_at',
-				'lang',
-			],
-			expansions: [
-				'attachments.media_keys',
-				'author_id',
-				'entities.mentions.username',
-			],
-			'media.fields': [
-				'alt_text',
-				'duration_ms',
-				'height',
-				'media_key',
-				'preview_image_url',
-				'type',
-				'url',
-				'variants',
-				'width',
-			],
-			'user.fields': ['name', 'profile_image_url', 'url', 'username'],
-		});
+		const oembedUrl = new URL('https://publish.twitter.com/oembed');
+		oembedUrl.searchParams.set('url', id);
+		oembedUrl.searchParams.set('omit_script', 'true');
+		oembedUrl.searchParams.set('dnt', 'true');
+		return (await fetch(oembedUrl).then((res) => res.json())) as {
+			url: string;
+			author_name: string;
+			author_url: string;
+			html: string;
+		};
 	} catch (e) {
 		console.error(
 			`[error]  astro-embed
          ${e.status} - ${e.statusText}: Failed to fetch tweet ${id}`
 		);
 	}
-	return {};
 }
 
-function buildContent(tweet: Awaited<ReturnType<typeof fetchTweet>>) {
-	if (!tweet.data) return {};
-
-	const author = tweet.includes.users.find(
-		(user) => user.id === tweet.data.author_id
-	);
-	const { name = '', username = '', profile_image_url = '' } = author;
-	let { created_at = '', text = '' } = tweet.data;
-	let images = [];
-	let video = '';
-	let imageCount = 0;
-
-	if (tweet.data.entities?.urls) {
-		tweet.data.entities.urls.forEach(
-			({ url, display_url, expanded_url, media_key }) => {
-				text = text.replace(
-					url,
-					media_key ? '' : `<a href=${expanded_url}>${display_url}</a>`
-				);
-			}
-		);
-	}
-
-	if (tweet.data.entities?.mentions) {
-		tweet.data.entities.mentions.forEach(({ username }) => {
-			text = text.replace(
-				`@${username}`,
-				`<a target="_blank" rel="noreferrer noopener" href="https://twitter.com/${username}">@${username}</a>`
-			);
-		});
-	}
-
-	if (tweet.data.entities?.hashtags) {
-		tweet.data.entities.hashtags.forEach(({ tag }) => {
-			text = text.replace(
-				`#${tag}`,
-				`<a target="_blank" rel="noreferrer noopener" href="https://twitter.com/hashtag/${tag}?src=hash&ref_src=twsrc">#${tag}</a>`
-			);
-		});
-	}
-
-	text = text.replace(/(?:\r\n|\r|\n)/g, '<br/>');
-
-	if (['video', 'animated_gif'].includes(tweet.includes.media?.[0]?.type)) {
-		const { width, height, variants, preview_image_url, type } = tweet.includes
-			.media[0] as components['schemas']['Video'];
-		const isGIF = type === 'animated_gif';
-		const aspect = `${width} / ${height}`;
-
-		video = `<video class="tweet-media-video" poster="${preview_image_url}" style="aspect-ratio: ${aspect};" controls loop ${
-			isGIF
-				? 'autoplay muted playsinline controlslist="nofullscreen"'
-				: 'preload="none"'
-		}>`;
-		variants.forEach(({ url, content_type }) => {
-			video += `<source src="${url}" type="${content_type}">`;
-		});
-		video += '</video>';
-	} else {
-		imageCount = tweet.includes.media?.length || 0;
-		(tweet.includes.media as components['schemas']['Photo'][])?.forEach(
-			({ url, width, height, alt_text = '' }) => {
-				images.push(
-					`<div><img class="tweet-media-img" src=${url} alt="${alt_text}" width="${width}" height="${height}" loading="lazy" /></div>`
-				);
-			}
-		);
-	}
-
-	return {
-		name,
-		username,
-		profile_image_url,
-		created_at,
-		text,
-		images: images.join(''),
-		imageCount,
-		video,
-		lang: tweet.data.lang,
-	};
-}
-
-const tweetID = extractID(id);
-const tweet = await fetchTweet(tweetID);
-const {
-	name,
-	username,
-	profile_image_url,
-	text,
-	images,
-	imageCount,
-	video,
-	lang,
-} = buildContent(tweet);
-const tweetLink = `https://twitter.com/${username}/status/${tweetID}`;
+const tweet = await fetchTweet(id);
 ---
 
-{
-	tweet.data && (
-		<blockquote class="tweet-card" cite={tweetLink}>
-			<div class="tweet-header">
-				<a class="tweet-profile" href={`https://twitter.com/${username}`}>
-					<img
-						src={profile_image_url}
-						alt={`Twitter avatar for ${username}`}
-						loading="lazy"
-						width="48"
-						height="48"
-					/>
-				</a>
-				<div class="tweet-author">
-					<a class="tweet-author-name" href={`https://twitter.com/${username}`}>
-						{name}
-					</a>
-					<a
-						class="tweet-author-handle"
-						href={`https://twitter.com/${username}`}
-					>
-						@{username}
-					</a>
-				</div>
-			</div>
-			<p class="tweet-body" {lang} set:html={text} />
-			{images && (
-				<div class={`tweet-img-grid-${imageCount}`} set:html={images} />
-			)}
-			{video && <div class="tweet-video-wrapper" set:html={video} />}
-			<div class="tweet-footer">
-				<a href={tweetLink} class="tweet-link">
-					Twitter
-				</a>
-			</div>
-		</blockquote>
-	)
-}
+{tweet && <astro-embed-tweet set:html={tweet.html} />}
+
+<script>
+	type ElementList = ReturnType<typeof document.querySelectorAll>;
+
+	// Based on https://github.com/withastro/astro/blob/main/packages/astro/src/runtime/client/visible.ts
+	const onVisible = <T extends ElementList>(nodes: T, callback: () => void) => {
+		const io = new IntersectionObserver((entries) => {
+			for (const { isIntersecting } of entries) {
+				if (!isIntersecting) continue;
+				// As soon as we hydrate, disconnect this IntersectionObserver.
+				io.disconnect();
+				callback();
+				break; // Break loop on first match.
+			}
+		});
+		for (const node of nodes) io.observe(node);
+	};
+
+	const embeds = document.querySelectorAll('astro-embed-tweet');
+	onVisible(embeds, () => {
+		const script = document.createElement('script');
+		script.setAttribute('defer', '');
+		script.setAttribute('src', 'https://platform.twitter.com/widgets.js');
+		// document.body.append(script);
+	});
+</script>

--- a/packages/astro-embed-twitter/Tweet.css
+++ b/packages/astro-embed-twitter/Tweet.css
@@ -1,94 +1,10 @@
-.tweet-card {
-	--tc-corner-radius: 1em;
-	--tc-padding: 1em;
-
-	padding: var(--tc-padding);
-	border-radius: var(--tc-corner-radius);
-	border: 1px solid currentColor;
-	box-shadow: 0 0.2px 0.5px hsl(0deg 0% 0% / 0.11),
-		0 0.75px 1.7px -0.8px hsl(0deg 0% 0% / 0.11),
-		0 1.85px 4.2px -1.7px hsl(0deg 0% 0% / 0.11),
-		0 4.45px 10px -2.5px hsl(0deg 0% 0% / 0.11);
+.twitter-tweet:not(.twitter-tweet-rendered) {
+	padding: var(--tc-padding, 1em);
+	border: 1px solid var(--tc-border-color, #cfd9de);
 }
-
-.tweet-card > * + * {
-	margin-top: 1em;
+.twitter-tweet:not(.twitter-tweet-rendered) > :first-child {
+	margin-top: 0;
 }
-
-.tweet-header {
-	display: grid;
-	grid-template-columns: 48px 1fr;
-	gap: 12px;
-	align-items: center;
-	white-space: nowrap;
-}
-
-.tweet-profile img {
-	display: block;
-	border-radius: 50%;
-	color: transparent;
-	text-decoration: none;
-}
-
-.tweet-author {
-	display: grid;
-}
-
-.tweet-header a {
-	color: currentColor;
-	text-decoration: none;
-}
-
-.tweet-author-name {
-	font-weight: bold;
-}
-
-[class^='tweet-media'] {
-	display: block;
-	width: 100%;
-	height: auto;
-	aspect-ratio: 2;
-	object-fit: cover;
-}
-
-[class^='tweet-img-grid'],
-.tweet-video-wrapper,
-.tweet-media-video {
-	border-radius: var(--tc-corner-radius);
-	overflow: hidden;
-	display: grid;
-	grid-template-columns: repeat(1, 1fr);
-}
-
-.tweet-img-grid-3 {
-	grid-template-columns: repeat(2, 1fr);
-}
-
-.tweet-img-grid-3 .tweet-media-img {
-	aspect-ratio: 1.8;
-}
-
-.tweet-img-grid-3 :nth-child(1) {
-	grid-row: 1 / span 2;
-}
-
-.tweet-img-grid-3 :nth-child(1) .tweet-media-img {
-	aspect-ratio: 0.9;
-}
-
-.tweet-img-grid-2,
-.tweet-img-grid-4 {
-	grid-template-columns: repeat(2, 1fr);
-}
-
-.tweet-footer {
-	text-align: center;
-}
-
-.tweet-link {
-	display: block;
-}
-
-.tweet-link::after {
-	content: ' →';
+.twitter-tweet:not(.twitter-tweet-rendered) > :last-child {
+	margin-bottom: 0;
 }

--- a/packages/astro-embed-twitter/matcher.js
+++ b/packages/astro-embed-twitter/matcher.js
@@ -4,11 +4,11 @@ const urlPattern =
 	/(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:)??(?:\/\/)??(?:w{3}\.)??(?:twitter\.com)\/([a-zA-Z0-9_]{1,15})?(?:\/(?:status)\/)(\d+)?(?:[^\s<>]*)(?=(\s*))\5(?:<\/a>)??(?=(\s*))\6/;
 
 /**
- * Extract a Tweet ID from a URL if it matches the pattern.
+ * Return a Tweet URL from a URL if it matches the pattern.
  * @param {string} url URL to test
  * @returns {string|undefined} A Tweet ID or undefined if none matched
  */
 export default function urlMatcher(url) {
 	const match = url.match(urlPattern);
-	return match?.[4];
+	return match?.[0];
 }

--- a/packages/astro-embed/README.md
+++ b/packages/astro-embed/README.md
@@ -8,9 +8,6 @@ Embed components for your Astro sites built by the Astro community 🚀
 npm i astro-embed
 ```
 
-> **Note**
-> Using the `<Tweet />` component? add a `SECRET_TWITTER_TOKEN` environment variable with your Twitter API bearer token. [Learn more in the component docs →](https://github.com/delucis/astro-embed/tree/main/packages/astro-embed-twitter#readme)
-
 ## Using the components
 
 ### `.astro` files

--- a/tests/astro-embed-twitter.ts
+++ b/tests/astro-embed-twitter.ts
@@ -1,14 +1,13 @@
 import { test } from 'uvu';
-import * as assert from 'uvu/assert';
 import { renderScreen } from './utils/render';
 
-test('it should render user information in the header', async () => {
+test('it should render user information in the footer', async () => {
 	const screen = await renderScreen(
 		'./packages/astro-embed-twitter/Tweet.astro',
-		{ id: '1511750228428435457' }
+		{ id: 'https://twitter.com/astrodotbuild/status/1511750228428435457' }
 	);
-	const username = screen.getByText('@astrodotbuild');
-	assert.is(username.getAttribute('href'), 'https://twitter.com/astrodotbuild');
+	screen.getByText(/@astrodotbuild/);
+	screen.getByText('April 6, 2022');
 });
 
 test('it should render if passed a full URL', async () => {
@@ -16,8 +15,8 @@ test('it should render if passed a full URL', async () => {
 		'./packages/astro-embed-twitter/Tweet.astro',
 		{ id: 'https://twitter.com/astrodotbuild/status/1402352777020395521' }
 	);
-	const username = screen.getByText('@astrodotbuild');
-	assert.is(username.getAttribute('href'), 'https://twitter.com/astrodotbuild');
+	screen.getByText(/@astrodotbuild/);
+	screen.getByText('June 8, 2021');
 });
 
 test('it does not crash when we have undefined entities', async () => {
@@ -25,8 +24,8 @@ test('it does not crash when we have undefined entities', async () => {
 		'./packages/astro-embed-twitter/Tweet.astro',
 		{ id: 'https://twitter.com/addyosmani/status/1600553460180869120' }
 	);
-	const username = screen.getByText('@addyosmani');
-	assert.is(username.getAttribute('href'), 'https://twitter.com/addyosmani');
+	screen.getByText(/@addyosmani/);
+	screen.getByText('December 7, 2022');
 });
 
 test.run();


### PR DESCRIPTION
This PR overhauls the `<Tweet />` component to remove the requirement for authentication with Twitter’s API, which is basically impossible in any case now that their “hobbyist” tier for reading tweets costs $100/month 🙄 

| Before | After |
|---|---|
| <img width="504" alt="Example embeds with the old approach, showing more metadata and rendered media" src="https://github.com/delucis/astro-embed/assets/357379/86d8fbcd-8b93-412b-9adf-ff409705db69"> | <img width="517" alt="The same embeds after this PR, showing a more minimal design" src="https://github.com/delucis/astro-embed/assets/357379/8d729ee8-53ea-465f-a348-a072c7f825b3"> |

Key differences:

- The `<Tweet />` component must now receive a full URL to a tweet, not just an ID. Users will need to update these if you have any:

   ```diff
   - <Tweet id="1511750228428435457" />
   + <Tweet id="https://twitter.com/astrodotbuild/status/1511750228428435457" />
   ```

- The rendered component is more minimal: no avatar for the tweet author; no header containing author name and handle; images and video are not expanded, only showing as links

- The CSS class name on the resulting HTML is now `twitter-tweet` instead of `tweet-card` and none of the internal class names like `tweet-author`, `tweet-header` etc. are available. Users will need to update any custom CSS they wrote.

- Authentication is no longer required. `SECRET_TWITTER_TOKEN` environment variables can be safely removed from project.

---

Because this is using [Twitter’s oEmbed API](https://developer.twitter.com/en/docs/twitter-for-websites/oembed-api) to retrieve HTML for tweets, it is also compatible with Twitter’s bloated widget JavaScript, which will convert the static HTML output into an interactive iframe. This is not included in the component to keep things lightweight, but instructions for adding it are included in the README.
