### PR TITLE
Add note about integration ordering

### DIFF
--- a/packages/astro-embed/README.md
+++ b/packages/astro-embed/README.md
@@ -65,9 +65,6 @@ export default defineConfig({
 });
 ```
 
-> [!IMPORTANT]
-> The `embeds()` integration must be listed before the `mdx()` integration.
-
 With the integration enabled, any isolated URL in an MDX file that matches one of the `astro-embed` component types will be converted to the appropriate component.
 
 For example, MDX like this will render an optimised YouTube player component in place of the URL.

--- a/packages/astro-embed/README.md
+++ b/packages/astro-embed/README.md
@@ -53,7 +53,7 @@ Vimeo and YouTube videos work too :-)
 
 You can use the provided integration to automatically convert standalone URLs in MDX files to embed components.
 
-To enable the integration, add it to the `integrations` array in your `astro.config.mjs` file:
+To enable the integration, add it to the `integrations` array in your `astro.config.mjs` file before the `mdx()` integration:
 
 ```js
 import { defineConfig } from 'astro/config';

--- a/packages/astro-embed/README.md
+++ b/packages/astro-embed/README.md
@@ -65,6 +65,9 @@ export default defineConfig({
 });
 ```
 
+> [!IMPORTANT]
+> The `embeds()` integration must be listed before the `mdx()` integration.
+
 With the integration enabled, any isolated URL in an MDX file that matches one of the `astro-embed` component types will be converted to the appropriate component.
 
 For example, MDX like this will render an optimised YouTube player component in place of the URL.


### PR DESCRIPTION
When I tried using this package, it wasn't working—my links remained as regular links. I use a few different integrations on my site and didn't think the order here mattered, but I found that the embeds integration only works when listed before the MDX integration.

This PR adds a callout to the README noting this requirement:

> [!IMPORTANT]
> The `embeds()` integration must be listed before the `mdx()` integration.