### PR TITLE
MDX integration embeds replace their parent paragraph instead of their link node

### DIFF
--- a/.changeset/little-fans-fold.md
+++ b/.changeset/little-fans-fold.md
@@ -1,0 +1,8 @@
+---
+"@astro-community/astro-embed-integration": minor
+---
+
+MDX integration embeds replace their parent paragraph instead of their link node
+
+⚠️ **Potentially breaking change:** embeds automatically injected in MDX using the Astro integration were previously wrapped in a `<p>` tag.
+This is no longer the case. This may cause changes in vertical spacing between embeds depending on your site’s CSS.

--- a/packages/astro-embed-integration/remark-plugin.ts
+++ b/packages/astro-embed-integration/remark-plugin.ts
@@ -1,4 +1,4 @@
-import { selectAll, Node } from 'unist-util-select';
+import { Node, select, selectAll } from 'unist-util-select';
 import twitterMatcher from '@astro-community/astro-embed-twitter/matcher';
 import vimeoMatcher from '@astro-community/astro-embed-vimeo/matcher';
 import youtubeMatcher from '@astro-community/astro-embed-youtube/matcher';
@@ -43,17 +43,19 @@ export default function createPlugin({
 	};
 
 	function transformer(tree: Node) {
-		const nodes: Link[] = selectAll('paragraph > link:only-child', tree);
+		const paragraphs = selectAll('paragraph', tree);
+		paragraphs.forEach((paragraph) => {
+			const link: Link | null = select(':scope > link:only-child', paragraph);
+			if (!link) return;
 
-		nodes.forEach((node) => {
-			const { url } = node;
+			const { url } = link;
 			// We’re only interested in HTTP links
 			if (!url?.startsWith('http')) return;
 
 			const component = getComponent(url);
 			if (component) {
 				// @ts-expect-error We’re overriding the initial node type with arbitrary data.
-				for (const key in component) node[key] = component[key];
+				for (const key in component) paragraph[key] = component[key];
 			}
 		});
 


### PR DESCRIPTION
Fixes #65

Previously, the remark plugin looked for the equivalent of `p > a:only-child` to find URLs to potentially replace with an embed and, when finding a URL match, replaced the link node. This resulted in DOM like `p > embed`.

#65 noticed this was causing issues if embed code included elements not permitted inside `<p>` (`<blockquote>` in the case of Twitter’s oEmbed markup). This causes HTML parsing to do some creative stuff and can cause some layout weirdness depending on what a user’s CSS looks like.

This PR updates the remark plugin to replace the full paragraph node with the embed instead of just the link, so this should no longer be an issue.

Existing embeds should render as expected without the wrapper `<p>` — although spacing between embeds may be impacted (`<p>` has default margins, but the embed nodes do not).