### PR TITLE
fix: YouTube embed height in Starlight #71

### DIFF
--- a/.changeset/tiny-kids-provide.md
+++ b/.changeset/tiny-kids-provide.md
@@ -1,0 +1,5 @@
+---
+"@astro-community/astro-embed-youtube": patch
+---
+
+Fix YouTube embed styling in environments that already apply `<iframe>` styles

--- a/package-lock.json
+++ b/package-lock.json
@@ -1940,9 +1940,9 @@
       "dev": true
     },
     "node_modules/@types/unist": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.9.tgz",
-      "integrity": "sha512-zC0iXxAv1C1ERURduJueYzkzZ2zaGyc+P2c95hgkikHPr3z8EdUZOlgEQ5X0DRmwDZn+hekycQnoeiiRVrmilQ=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.0",
@@ -9747,11 +9747,11 @@
       }
     },
     "packages/astro-embed": {
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@astro-community/astro-embed-integration": "^0.5.1",
-        "@astro-community/astro-embed-twitter": "^0.5.1",
+        "@astro-community/astro-embed-integration": "^0.6.0",
+        "@astro-community/astro-embed-twitter": "^0.5.2",
         "@astro-community/astro-embed-vimeo": "^0.3.1",
         "@astro-community/astro-embed-youtube": "^0.4.1"
       },
@@ -9761,10 +9761,10 @@
     },
     "packages/astro-embed-integration": {
       "name": "@astro-community/astro-embed-integration",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@astro-community/astro-embed-twitter": "^0.5.1",
+        "@astro-community/astro-embed-twitter": "^0.5.2",
         "@astro-community/astro-embed-vimeo": "^0.3.1",
         "@astro-community/astro-embed-youtube": "^0.4.1",
         "@types/unist": "^2.0.0",
@@ -9782,7 +9782,7 @@
     },
     "packages/astro-embed-twitter": {
       "name": "@astro-community/astro-embed-twitter",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@astro-community/astro-embed-utils": "^0.1.0"
@@ -9855,7 +9855,7 @@
     "@astro-community/astro-embed-integration": {
       "version": "file:packages/astro-embed-integration",
       "requires": {
-        "@astro-community/astro-embed-twitter": "^0.5.1",
+        "@astro-community/astro-embed-twitter": "^0.5.2",
         "@astro-community/astro-embed-vimeo": "^0.3.1",
         "@astro-community/astro-embed-youtube": "^0.4.1",
         "@types/unist": "^2.0.0",
@@ -11282,9 +11282,9 @@
       "dev": true
     },
     "@types/unist": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.9.tgz",
-      "integrity": "sha512-zC0iXxAv1C1ERURduJueYzkzZ2zaGyc+P2c95hgkikHPr3z8EdUZOlgEQ5X0DRmwDZn+hekycQnoeiiRVrmilQ=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "@types/yargs-parser": {
       "version": "21.0.0",
@@ -11668,8 +11668,8 @@
     "astro-embed": {
       "version": "file:packages/astro-embed",
       "requires": {
-        "@astro-community/astro-embed-integration": "^0.5.1",
-        "@astro-community/astro-embed-twitter": "^0.5.1",
+        "@astro-community/astro-embed-integration": "^0.6.0",
+        "@astro-community/astro-embed-twitter": "^0.5.2",
         "@astro-community/astro-embed-vimeo": "^0.3.1",
         "@astro-community/astro-embed-youtube": "^0.4.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1940,9 +1940,9 @@
       "dev": true
     },
     "node_modules/@types/unist": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
-      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.9.tgz",
+      "integrity": "sha512-zC0iXxAv1C1ERURduJueYzkzZ2zaGyc+P2c95hgkikHPr3z8EdUZOlgEQ5X0DRmwDZn+hekycQnoeiiRVrmilQ=="
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.0",
@@ -9747,11 +9747,11 @@
       }
     },
     "packages/astro-embed": {
-      "version": "0.6.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@astro-community/astro-embed-integration": "^0.6.0",
-        "@astro-community/astro-embed-twitter": "^0.5.2",
+        "@astro-community/astro-embed-integration": "^0.5.1",
+        "@astro-community/astro-embed-twitter": "^0.5.1",
         "@astro-community/astro-embed-vimeo": "^0.3.1",
         "@astro-community/astro-embed-youtube": "^0.4.1"
       },
@@ -9761,10 +9761,10 @@
     },
     "packages/astro-embed-integration": {
       "name": "@astro-community/astro-embed-integration",
-      "version": "0.6.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@astro-community/astro-embed-twitter": "^0.5.2",
+        "@astro-community/astro-embed-twitter": "^0.5.1",
         "@astro-community/astro-embed-vimeo": "^0.3.1",
         "@astro-community/astro-embed-youtube": "^0.4.1",
         "@types/unist": "^2.0.0",
@@ -9782,7 +9782,7 @@
     },
     "packages/astro-embed-twitter": {
       "name": "@astro-community/astro-embed-twitter",
-      "version": "0.5.2",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@astro-community/astro-embed-utils": "^0.1.0"
@@ -9855,7 +9855,7 @@
     "@astro-community/astro-embed-integration": {
       "version": "file:packages/astro-embed-integration",
       "requires": {
-        "@astro-community/astro-embed-twitter": "^0.5.2",
+        "@astro-community/astro-embed-twitter": "^0.5.1",
         "@astro-community/astro-embed-vimeo": "^0.3.1",
         "@astro-community/astro-embed-youtube": "^0.4.1",
         "@types/unist": "^2.0.0",
@@ -11282,9 +11282,9 @@
       "dev": true
     },
     "@types/unist": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
-      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.9.tgz",
+      "integrity": "sha512-zC0iXxAv1C1ERURduJueYzkzZ2zaGyc+P2c95hgkikHPr3z8EdUZOlgEQ5X0DRmwDZn+hekycQnoeiiRVrmilQ=="
     },
     "@types/yargs-parser": {
       "version": "21.0.0",
@@ -11668,8 +11668,8 @@
     "astro-embed": {
       "version": "file:packages/astro-embed",
       "requires": {
-        "@astro-community/astro-embed-integration": "^0.6.0",
-        "@astro-community/astro-embed-twitter": "^0.5.2",
+        "@astro-community/astro-embed-integration": "^0.5.1",
+        "@astro-community/astro-embed-twitter": "^0.5.1",
         "@astro-community/astro-embed-vimeo": "^0.3.1",
         "@astro-community/astro-embed-youtube": "^0.4.1"
       }

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -33,3 +33,10 @@ const posterURL = poster || `https://i.ytimg.com/vi/${videoid}/hqdefault.jpg`;
 <script>
 	import 'lite-youtube-embed';
 </script>
+
+<style is:global>
+	lite-youtube > iframe {
+		margin-top: 0 !important;
+		height: 100% !important;
+	}
+</style>

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -36,7 +36,11 @@ const posterURL = poster || `https://i.ytimg.com/vi/${videoid}/hqdefault.jpg`;
 
 <style is:global>
 	lite-youtube > iframe {
-		margin-top: 0 !important;
+		all: unset !important;
+		width: 100% !important;
 		height: 100% !important;
+		position: absolute !important;
+		inset: 0 !important;
+		border: 0 !important;
 	}
 </style>


### PR DESCRIPTION
Hi. I think is supposed to be upstream on lite-youtube, or even Starlight (maybe not as it was already discussed there) in not sure, but I'm opening this here and see where it goes.
This aims to solve #71

It basically overrides the CSS that is setting `height` to auto and `margin-top` to 1.5rem in Starlight `markdown.css`: [Line 4](https://github.com/withastro/starlight/blob/0c25c1f33bbfe311724784530c30ada44eb5de19/packages/starlight/style/markdown.css#L4) and 
[Line 43](https://github.com/withastro/starlight/blob/0c25c1f33bbfe311724784530c30ada44eb5de19/packages/starlight/style/markdown.css#L43).

For reference, after these changes:
<img width="60%" src="https://github.com/delucis/astro-embed/assets/61759797/45999142-e302-4062-ab6b-0e5bf6b9f4ff"/>

Thank you.