### PR TITLE
Add support for `/shorts/` URLs in YouTube URL matcher

### DIFF
--- a/.changeset/shiny-rivers-rule.md
+++ b/.changeset/shiny-rivers-rule.md
@@ -1,0 +1,5 @@
+---
+"@astro-community/astro-embed-youtube": patch
+---
+
+Add support for `/shorts/` URLs in YouTube URL matcher

--- a/packages/astro-embed-youtube/matcher.ts
+++ b/packages/astro-embed-youtube/matcher.ts
@@ -1,7 +1,7 @@
 // Thanks to eleventy-plugin-youtube-embed
 // https://github.com/gfscott/eleventy-plugin-youtube-embed/blob/main/lib/extractMatches.js
 const urlPattern =
-	/(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5/;
+	/(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/|shorts\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5/;
 
 /**
  * Extract a YouTube ID from a URL if it matches the pattern.

--- a/tests/astro-embed-youtube.ts
+++ b/tests/astro-embed-youtube.ts
@@ -47,6 +47,17 @@ test('it parses an embed URL', async () => {
 	assert.is(embed.getAttribute('videoid'), videoid);
 });
 
+test('it parses a YouTube shorts URL', async () => {
+	const videoid = 'zjOWezSzd18';
+	const { window } = await renderDOM(
+		'./packages/astro-embed-youtube/YouTube.astro',
+		{ id: 'https://www.youtube.com/shorts/' + videoid }
+	);
+	const embed = window.document.querySelector('lite-youtube');
+	assert.ok(embed);
+	assert.is(embed.getAttribute('videoid'), videoid);
+});
+
 test('it can set a custom poster image', async () => {
 	const poster = 'https://example.com/i.png';
 	const { window } = await renderDOM(


### PR DESCRIPTION
YouTube Shorts shave a different URL format sometimes not accounted for in the current matcher regular expression. This PR updates that to correctly extract video IDs from `/shorts/` URLs.