### PR TITLE
Upgrade lite-youtube-embed from 0.2.0 to 0.3.2

### DIFF
--- a/.changeset/old-crabs-argue.md
+++ b/.changeset/old-crabs-argue.md
@@ -1,0 +1,5 @@
+---
+"@astro-community/astro-embed-youtube": patch
+---
+
+Updates internal `lite-youtube-embed` dependency from 0.2.0 to 0.3.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -5346,9 +5346,9 @@
       }
     },
     "node_modules/lite-youtube-embed": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.2.0.tgz",
-      "integrity": "sha512-XXXAk5sbvtjjwbie3XG+6HppgTm1HTGL/Uk9z9NkJH53o7puZLur434heHzAjkS60hZB3vT4ls25zl5rMiX4EA=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.2.tgz",
+      "integrity": "sha512-b1dgKyF4PHhinonmr3PB172Nj0qQgA/7DE9EmeIXHR1ksnFEC2olWjNJyJGdsN2cleKHRjjsmrziKlwXtPlmLQ=="
     },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
@@ -9809,7 +9809,7 @@
       "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
-        "lite-youtube-embed": "^0.2.0"
+        "lite-youtube-embed": "^0.3.2"
       },
       "peerDependencies": {
         "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
@@ -9885,7 +9885,7 @@
     "@astro-community/astro-embed-youtube": {
       "version": "file:packages/astro-embed-youtube",
       "requires": {
-        "lite-youtube-embed": "^0.2.0"
+        "lite-youtube-embed": "^0.3.2"
       }
     },
     "@astrojs/compiler": {
@@ -13486,9 +13486,9 @@
       }
     },
     "lite-youtube-embed": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.2.0.tgz",
-      "integrity": "sha512-XXXAk5sbvtjjwbie3XG+6HppgTm1HTGL/Uk9z9NkJH53o7puZLur434heHzAjkS60hZB3vT4ls25zl5rMiX4EA=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.2.tgz",
+      "integrity": "sha512-b1dgKyF4PHhinonmr3PB172Nj0qQgA/7DE9EmeIXHR1ksnFEC2olWjNJyJGdsN2cleKHRjjsmrziKlwXtPlmLQ=="
     },
     "load-yaml-file": {
       "version": "0.2.0",

--- a/packages/astro-embed-youtube/package.json
+++ b/packages/astro-embed-youtube/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/delucis/astro-embed/tree/main/packages/astro-embed-youtube#readme",
   "dependencies": {
-    "lite-youtube-embed": "^0.2.0"
+    "lite-youtube-embed": "^0.3.2"
   },
   "peerDependencies": {
     "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"


### PR DESCRIPTION
`lite-youtube-embed` [v0.3.0](https://github.com/paulirish/lite-youtube-embed/releases/tag/v0.3.0) and [v0.3.1](https://github.com/paulirish/lite-youtube-embed/releases/tag/v0.3.1) come with some nice improvements!