### PR TITLE
Add `posterQuality` prop to `<YouTube>`

### DIFF
--- a/.changeset/hot-experts-reflect.md
+++ b/.changeset/hot-experts-reflect.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-youtube': patch
+---
+
+Adds a new `posterQuality` prop to the `<YouTube>` component to control the resolution of the poster image.

--- a/docs/src/content/docs/components/youtube.mdx
+++ b/docs/src/content/docs/components/youtube.mdx
@@ -63,6 +63,27 @@ For example, this is the same video as above but with a custom poster image:
 	poster="https://images-assets.nasa.gov/image/0302063/0302063~medium.jpg"
 />
 
+### `posterQuality`
+
+**Type:** `'max' | 'high' | 'default' | 'low'`  
+**Default:** `'default'`
+
+When using the default YouTube poster image, set the `posterQuality` to change the size of the placeholder image.
+This can be useful if displaying the embed at very large or very small sizes.
+
+| `posterQuality` | resolution |
+| --------------- | ---------- |
+| `'low'`         | 120px      |
+| `'default'`     | 480px      |
+| `'high'`        | 640px      |
+| `'max'`         | 1280px     |
+
+```astro
+<YouTube id="TtRtkTzHVBU" posterQuality="low" />
+```
+
+<YouTube id="TtRtkTzHVBU" posterQuality="low" />
+
 ### `params`
 
 You can pass in a `params` prop to set the [YouTube player parameters](https://developers.google.com/youtube/player_parameters#Parameters). This looks like a series of URL search params.

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -5,11 +5,17 @@ import urlMatcher from './matcher';
 export interface Props extends astroHTML.JSX.HTMLAttributes {
 	id: string;
 	poster?: string;
+	posterQuality?: 'max' | 'high' | 'default' | 'low';
 	params?: string;
 	playlabel?: string;
 }
 
-const { id, poster, ...attrs } = Astro.props as Props;
+const {
+	id,
+	poster,
+	posterQuality = 'default',
+	...attrs
+} = Astro.props as Props;
 
 const idRegExp = /^[A-Za-z0-9-_]+$/;
 
@@ -19,8 +25,15 @@ function extractID(idOrUrl: string) {
 }
 
 const videoid = extractID(id);
+const posterFile =
+	{
+		max: 'maxresdefault',
+		high: 'sddefault',
+		default: 'hqdefault',
+		low: 'default',
+	}[posterQuality] || 'hqdefault';
 const posterURL =
-	poster || `https://i.ytimg.com/vi_webp/${videoid}/hqdefault.webp`;
+	poster || `https://i.ytimg.com/vi_webp/${videoid}/${posterFile}.webp`;
 const href = `https://youtube.com/watch?v=${videoid}`;
 ---
 

--- a/tests/astro-embed-youtube.mjs
+++ b/tests/astro-embed-youtube.mjs
@@ -75,4 +75,17 @@ test('it can set a custom poster image', async () => {
 	assert.is(embed.style['background-image'], `url('${poster}')`);
 });
 
+test('it can render a lower resolution poster image', async () => {
+	const { window } = await renderDOM(
+		'./packages/astro-embed-youtube/YouTube.astro',
+		{ id: videoid, posterQuality: 'low' }
+	);
+	const embed = window.document.querySelector('lite-youtube');
+	assert.ok(embed);
+	assert.is(
+		embed.style['background-image'],
+		`url('https://i.ytimg.com/vi_webp/${videoid}/default.webp')`
+	);
+});
+
 test.run();


### PR DESCRIPTION
Adds a `posterQuality` prop to the YouTube component for selecting higher or lower resolutions of the YouTube poster image.