### PR TITLE
Improve `title` attribute support in `<YouTube>` and document it

### DIFF
--- a/.changeset/spicy-phones-visit.md
+++ b/.changeset/spicy-phones-visit.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-youtube': patch
+---
+
+Improves support for the `title` attribute in the YouTube component

--- a/docs/src/content/docs/components/youtube.mdx
+++ b/docs/src/content/docs/components/youtube.mdx
@@ -47,6 +47,8 @@ In addition to the required `id` prop, the following props are available to cust
 
 ### `poster`
 
+**Type:** `string`
+
 You can provide an alternative poster image by passing in a URL to the `poster` prop.
 
 For example, this is the same video as above but with a custom poster image:
@@ -98,12 +100,33 @@ For example, the following `params` value sets the start and end times of the vi
 
 ### `playlabel`
 
+**Type:** `string`  
+**Default:** `'Play'`
+
 By default, the play button in the embed has an accessible label set to “Play”.
 If you want to customise this, for example to match the language of your website, you can set the `playlabel` prop:
 
 ```astro
 <YouTube id="TtRtkTzHVBU" playlabel="Play the video" />
 ```
+
+### `title`
+
+**Type:** `string`
+
+Set a visible title to overlay on the video.
+
+```astro
+<YouTube
+	id="TtRtkTzHVBU"
+	title="The Astro Community: where contributors find a home"
+/>
+```
+
+<YouTube
+	id="TtRtkTzHVBU"
+	title="The Astro Community: where contributors find a home"
+/>
 
 ## Standalone installation
 

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -14,6 +14,7 @@ const {
 	id,
 	poster,
 	posterQuality = 'default',
+	title,
 	...attrs
 } = Astro.props as Props;
 
@@ -39,6 +40,8 @@ const href = `https://youtube.com/watch?v=${videoid}`;
 
 <lite-youtube
 	{videoid}
+	{title}
+	data-title={title}
 	{...attrs}
 	style={`background-image: url('${posterURL}');`}
 >

--- a/tests/astro-embed-youtube.mjs
+++ b/tests/astro-embed-youtube.mjs
@@ -88,4 +88,14 @@ test('it can render a lower resolution poster image', async () => {
 	);
 });
 
+test('title attribute also sets `data-title`', async () => {
+	const { window } = await renderDOM(
+		'./packages/astro-embed-youtube/YouTube.astro',
+		{ id: videoid, title: 'Example title' }
+	);
+	const embed = window.document.querySelector('lite-youtube');
+	assert.ok(embed);
+	assert.is(embed.dataset.title, 'Example title');
+});
+
 test.run();


### PR DESCRIPTION
- Uses `title` to set `data-title` at build time so it displays before the custom element is defined
- Documents that this attribute exists.