### PR TITLE
Vimeo component improvements

### DIFF
--- a/.changeset/big-years-sing.md
+++ b/.changeset/big-years-sing.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-vimeo': patch
+---
+
+Tweaks the play button styles to match Vimeo style more closely

--- a/.changeset/giant-coats-heal.md
+++ b/.changeset/giant-coats-heal.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-vimeo': patch
+---
+
+Uses progressive enhancement pattern to display a link to the Vimeo video until the `<lite-vimeo>` JavaScript loads

--- a/.changeset/quick-news-double.md
+++ b/.changeset/quick-news-double.md
@@ -1,0 +1,7 @@
+---
+'@astro-community/astro-embed-vimeo': patch
+---
+
+Adds a `posterQuality` prop to `<Vimeo>`
+
+The new default resolution is 480px instead of 640px. Set `posterQuality="high"` to use the previous 640px resolution.

--- a/docs/src/content/docs/components/vimeo.mdx
+++ b/docs/src/content/docs/components/vimeo.mdx
@@ -47,6 +47,8 @@ In addition to the required `id` prop, the following props are available to cust
 
 ### `poster`
 
+**Type:** `string`
+
 You can provide an alternative poster image by passing in a URL to the `poster` prop.
 
 For example, this is the same video as above but with a custom poster image:
@@ -63,6 +65,27 @@ For example, this is the same video as above but with a custom poster image:
 	poster="https://images-assets.nasa.gov/image/0302063/0302063~medium.jpg"
 />
 
+### `posterQuality`
+
+**Type:** `'max' | 'high' | 'default' | 'low'`  
+**Default:** `'default'`
+
+When using the default Vimeo poster image, set the `posterQuality` to change the size of the placeholder image.
+This can be useful if displaying the embed at very large or very small sizes.
+
+| `posterQuality` | resolution |
+| --------------- | ---------- |
+| `'low'`         | 120px      |
+| `'default'`     | 480px      |
+| `'high'`        | 640px      |
+| `'max'`         | 1280px     |
+
+```astro
+<Vimeo id="32001208" posterQuality="low" />
+```
+
+<Vimeo id="32001208" posterQuality="low" />
+
 ### `params`
 
 You can pass a `params` prop to set the [player parameters supported by Vimeo](https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview). This looks like a series of URL search params.
@@ -76,6 +99,9 @@ For example, the following `params` value sets the UI color to red and mutes the
 <Vimeo id="32001208" params="color=ff0000&muted=1" />
 
 ### `playlabel`
+
+**Type:** `string`  
+**Default:** `'Play'`
 
 By default, the play button in the embed has an accessible label set to “Play”.
 If you want to customise this, for example to match the language of your website, you can set the `playlabel` prop:

--- a/packages/astro-embed-vimeo/Vimeo.astro
+++ b/packages/astro-embed-vimeo/Vimeo.astro
@@ -64,18 +64,19 @@ if (posterURL) styles.push(`background-image: url('${posterURL}')`);
 	data-params={searchParams.toString()}
 	style={styles.join(';')}
 >
-	<button class="ltv-playbtn" type="button" aria-label={playlabel}></button>
+	<a
+		class="ltv-playbtn"
+		href={`https://vimeo.com/${videoid}`}
+		aria-label={playlabel}></a>
 </lite-vimeo>
 
 <script>
 	class LiteVimeo extends HTMLElement {
-		videoId: string;
+		// Gotta encode the untrusted value to prevent XSS.
+		videoId = encodeURIComponent(this.dataset.id!);
 		static preconnected = false;
 
 		connectedCallback() {
-			// Gotta encode the untrusted value to prevent XSS.
-			this.videoId = encodeURIComponent(this.dataset.id);
-
 			// On hover (or tap), warm up the TCP connections we're (likely) about to use.
 			this.addEventListener('pointerover', LiteVimeo.warmConnections, {
 				once: true,
@@ -83,6 +84,18 @@ if (posterURL) styles.push(`background-image: url('${posterURL}')`);
 
 			// Once the user clicks, add the real iframe and drop our play button
 			this.addEventListener('click', (e) => this.addIframe(e));
+
+			// Progressively enhance the link to the Vimeo as a play button.
+			const playLink = this.querySelector('a');
+			if (playLink) {
+				const playBtn = document.createElement('button');
+				playBtn.classList.add(...playLink.classList.values());
+				playBtn.setAttribute(
+					'aria-label',
+					playLink.getAttribute('aria-label')!
+				);
+				playLink.replaceWith(playBtn);
+			}
 		}
 
 		/**

--- a/packages/astro-embed-vimeo/Vimeo.astro
+++ b/packages/astro-embed-vimeo/Vimeo.astro
@@ -8,13 +8,21 @@ export interface Props {
 	id: string;
 	/** URL to an image to use as the poster instead of the default thumbnail. */
 	poster?: string;
+	/** Resolution to use for the Vimeo poster image. */
+	posterQuality?: 'max' | 'high' | 'default' | 'low';
 	/** See https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview */
 	params?: string;
 	/** Label for the button that will play the video. Default label: `'Play'` */
 	playlabel?: string;
 }
 
-const { id, poster, params = '', playlabel = 'Play' } = Astro.props as Props;
+const {
+	id,
+	poster,
+	posterQuality = 'default',
+	params = '',
+	playlabel = 'Play',
+} = Astro.props as Props;
 
 const idRegExp = /^\d+$/;
 
@@ -27,8 +35,14 @@ const videoid = extractID(id);
 let posterURL = poster;
 if (!posterURL) {
 	const data = await safeGet(`https://vimeo.com/api/v2/video/${videoid}.json`);
+	const resolution =
+		{ max: 1280, high: 640, default: 480, low: 120 }[posterQuality] || 480;
 	const { thumbnail_large } = data?.[0] || {};
-	posterURL = thumbnail_large;
+	if (thumbnail_large.endsWith('d_640')) {
+		posterURL = thumbnail_large.slice(0, -3) + resolution;
+	} else {
+		posterURL = thumbnail_large;
+	}
 }
 
 let [searchString, t] = params.split('#t=');

--- a/packages/astro-embed-vimeo/Vimeo.css
+++ b/packages/astro-embed-vimeo/Vimeo.css
@@ -6,7 +6,6 @@ lite-vimeo {
 	contain: content;
 	background-position: center center;
 	background-size: cover;
-	cursor: pointer;
 }
 
 /* responsive iframe with a 16:9 aspect ratio
@@ -28,31 +27,41 @@ lite-vimeo > iframe {
 
 /* play button */
 lite-vimeo > .ltv-playbtn {
-	width: 6.5em;
-	height: 4em;
-	background: rgba(23, 35, 34, 0.75);
-	z-index: 1;
-	opacity: 0.8;
-	border-radius: 0.25rem;
-	transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+	content: '';
+	position: absolute;
+	inset: 0;
+	background: transparent;
+	outline: 0;
 	border: 0;
 	cursor: pointer;
 }
-lite-vimeo:hover > .ltv-playbtn {
+
+lite-vimeo > .ltv-playbtn::before {
+	width: 6.5em;
+	height: 4em;
+	background: rgba(23, 35, 34, 0.75);
+	opacity: 0.8;
+	border-radius: 0.25rem;
+	transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+lite-vimeo > .ltv-playbtn:focus::before {
+	outline: auto;
+}
+lite-vimeo:hover > .ltv-playbtn::before {
 	background-color: rgb(0, 173, 239);
-	background-color: var(--ltv-color, rgb(0, 173, 239));
+	background-color: var(--ltv-color, #00adef);
 	opacity: 1;
 }
 /* play button triangle */
-lite-vimeo > .ltv-playbtn::before {
-	content: '';
+lite-vimeo > .ltv-playbtn::after {
 	border-style: solid;
-	border-width: 10px 0 10px 17px;
+	border-width: 1em 0 1em 1.7em;
 	border-color: transparent transparent transparent #fff;
 }
 
-lite-vimeo > .ltv-playbtn,
-lite-vimeo > .ltv-playbtn::before {
+lite-vimeo > .ltv-playbtn::before,
+lite-vimeo > .ltv-playbtn::after {
+	content: '';
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -60,11 +69,9 @@ lite-vimeo > .ltv-playbtn::before {
 }
 
 /* Post-click styles */
-lite-vimeo.ltv-activated {
-	cursor: unset;
-}
 lite-vimeo.ltv-activated::before,
 lite-vimeo.ltv-activated > .ltv-playbtn {
+	cursor: unset;
 	opacity: 0;
 	pointer-events: none;
 }

--- a/packages/astro-embed-vimeo/Vimeo.css
+++ b/packages/astro-embed-vimeo/Vimeo.css
@@ -33,9 +33,8 @@ lite-vimeo > .ltv-playbtn {
 	background: rgba(23, 35, 34, 0.75);
 	z-index: 1;
 	opacity: 0.8;
-	border-radius: 0.5em; /* TODO: Consider replacing this with YT's actual svg. Eh. */
+	border-radius: 0.25rem;
 	transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
-	outline: 0;
 	border: 0;
 	cursor: pointer;
 }
@@ -48,7 +47,7 @@ lite-vimeo:hover > .ltv-playbtn {
 lite-vimeo > .ltv-playbtn::before {
 	content: '';
 	border-style: solid;
-	border-width: 10px 0 10px 20px;
+	border-width: 10px 0 10px 17px;
 	border-color: transparent transparent transparent #fff;
 }
 


### PR DESCRIPTION
- Tweaks play button style to better match Vimeo’s.
- Adds a `posterQuality` prop like the YouTube component has and sets a default of `480px` instead of `640px` to match YT.
- Uses a progressive enhancement pattern to display a link to the Vimeo video until the `<lite-vimeo>` JavaScript loads