### PR TITLE
Add `downloadPoster` prop

### DIFF
--- a/demo/astro.config.mjs
+++ b/demo/astro.config.mjs
@@ -4,5 +4,8 @@ import embed from 'astro-embed/integration';
 
 // https://astro.build/config
 export default defineConfig({
+	image: {
+		domains: ['i.ytimg.com', 'i.vimeocdn.com', 'astro.build'],
+	},
 	integrations: [embed(), mdx()],
 });

--- a/docs/src/content/docs/components/link-preview.mdx
+++ b/docs/src/content/docs/components/link-preview.mdx
@@ -105,6 +105,32 @@ The `<LinkPreview>` component supports the following API for controlling its sty
 - `.link-preview--no-media`: Class applied to the card when it includes no image or video.
 - `.link-preview--no-metadata`: Class applied when metadata scraping failed, or no valid title was found. In this case the only contents of the card is the original URL link.
 
+## Optional props
+
+In addition to the required `id` prop, the following props are available to customise how the `<LinkPreview>` component renders:
+
+### `downloadPoster`
+
+**Type:** `boolean`
+
+Download the poster image and host it on the same server as your website.
+
+This attribute can only be used if the `og:image` metadata exists.
+
+```astro
+<LinkPreview id="https://astro.build/blog/welcome-world/" downloadPoster />
+```
+
+To use the `downloadPoster` attribute, need to add the address of the image server to astro.config.mjs as follows:
+
+```js
+export default defineConfig({
+	image: {
+		domains: ['astro.build'],
+	},
+});
+```
+
 ## Standalone installation
 
 If you only need the `<LinkPreview>` component, you can install the package directly instead of the main `astro-embed` package:

--- a/docs/src/content/docs/components/vimeo.mdx
+++ b/docs/src/content/docs/components/vimeo.mdx
@@ -110,6 +110,27 @@ If you want to customise this, for example to match the language of your website
 <Vimeo id="32001208" playlabel="Play the video" />
 ```
 
+### `downloadPoster`
+
+**Type:** `boolean`
+
+Download the poster image and host it on the same server as your website.
+
+```astro
+<Vimeo id="32001208" downloadPoster />
+```
+
+To use the `downloadPoster` attribute, need to add the address of the image server to astro.config.mjs as follows:
+
+
+```js
+export default defineConfig({
+	image: {
+		domains: ['i.vimeocdn.com'],
+	},
+});
+```
+
 ## Standalone installation
 
 If you only need the `<Vimeo>` component, you can install the package directly instead of the main `astro-embed` package:

--- a/docs/src/content/docs/components/youtube.mdx
+++ b/docs/src/content/docs/components/youtube.mdx
@@ -128,6 +128,27 @@ Set a visible title to overlay on the video.
 	title="The Astro Community: where contributors find a home"
 />
 
+### `downloadPoster`
+
+**Type:** `boolean`
+
+Download the poster image and host it on the same server as your website.
+
+```astro
+<YouTube id="TtRtkTzHVBU" downloadPoster />
+```
+
+To use the `downloadPoster` attribute, need to add the address of the image server to astro.config.mjs as follows:
+
+
+```js
+export default defineConfig({
+	image: {
+		domains: ['i.ytimg.com'],
+	},
+});
+```
+
 ## Standalone installation
 
 If you only need the `<YouTube>` component, you can install the package directly instead of the main `astro-embed` package:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13067,7 +13067,7 @@
     },
     "packages/astro-embed-utils": {
       "name": "@astro-community/astro-embed-utils",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "linkedom": "^0.14.26"

--- a/packages/astro-embed-link-preview/LinkPreview.astro
+++ b/packages/astro-embed-link-preview/LinkPreview.astro
@@ -4,11 +4,12 @@ import { parseOpenGraph } from './lib';
 export interface Props {
 	/** URL to fetch Open Graph data. */
 	id: string;
+	downloadPoster?: boolean;
 }
 
-const { id } = Astro.props;
+const { id, downloadPoster } = Astro.props;
 
-const meta = await parseOpenGraph(id);
+const meta = await parseOpenGraph(id, downloadPoster);
 const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
 ---
 

--- a/packages/astro-embed-link-preview/lib.ts
+++ b/packages/astro-embed-link-preview/lib.ts
@@ -1,4 +1,5 @@
 import { safeGetDOM } from '@astro-community/astro-embed-utils';
+import { getImage } from 'astro:assets';
 
 /** Helper to get the `content` attribute of an element. */
 const getContent = (el: Element | null) => el?.getAttribute('content');
@@ -10,7 +11,10 @@ const urlOrNull = (url: string | null | undefined) =>
  * Loads and parses an HTML page to return Open Graph metadata.
  * @param pageUrl URL to parse
  */
-export async function parseOpenGraph(pageUrl: string) {
+export async function parseOpenGraph(
+	pageUrl: string,
+	downloadPoster: boolean = false
+) {
 	const html = await safeGetDOM(pageUrl);
 	if (!html) return;
 
@@ -23,11 +27,16 @@ export async function parseOpenGraph(pageUrl: string) {
 		getMetaProperty('og:title') || html.querySelector('title')?.textContent;
 	const description =
 		getMetaProperty('og:description') || getMetaName('description');
-	const image = urlOrNull(
+	const imageURL = urlOrNull(
 		getMetaProperty('og:image:secure_url') ||
 			getMetaProperty('og:image:url') ||
 			getMetaProperty('og:image')
 	);
+
+	const image =
+		downloadPoster && imageURL
+			? (await getImage({ src: imageURL, inferSize: true, format: 'webp' })).src
+			: imageURL;
 	const imageAlt = getMetaProperty('og:image:alt');
 	const video = urlOrNull(
 		getMetaProperty('og:video:secure_url') ||

--- a/packages/astro-embed-vimeo/Vimeo.astro
+++ b/packages/astro-embed-vimeo/Vimeo.astro
@@ -2,6 +2,7 @@
 import { safeGet } from '@astro-community/astro-embed-utils';
 import urlMatcher from './matcher';
 import './Vimeo.css';
+import { getImage } from 'astro:assets';
 
 export interface Props extends astroHTML.JSX.HTMLAttributes {
 	/** Vimeo video ID or URL. */
@@ -14,6 +15,8 @@ export interface Props extends astroHTML.JSX.HTMLAttributes {
 	params?: string;
 	/** Label for the button that will play the video. Default label: `'Play'` */
 	playlabel?: string;
+	/** Download the poster image. */
+	downloadPoster?: boolean;
 }
 
 const {
@@ -22,6 +25,7 @@ const {
 	posterQuality = 'default',
 	params = '',
 	playlabel = 'Play',
+	downloadPoster,
 	style,
 	...attrs
 } = Astro.props as Props;
@@ -46,6 +50,10 @@ if (!posterURL) {
 		posterURL = thumbnail_large;
 	}
 }
+const posterSource =
+	downloadPoster && posterURL
+		? (await getImage({ src: posterURL, inferSize: true, format: 'webp' })).src
+		: posterURL;
 
 let [searchString, t] = params.split('#t=');
 const searchParams = new URLSearchParams(searchString);
@@ -58,7 +66,7 @@ const color = searchParams.get('color');
 const styles = [];
 if (style) styles.push(style);
 if (color) styles.push(`--ltv-color: #${color}`);
-if (posterURL) styles.push(`background-image: url('${posterURL}')`);
+if (posterURL) styles.push(`background-image: url('${posterSource}')`);
 ---
 
 <lite-vimeo

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -1,6 +1,7 @@
 ---
 import 'lite-youtube-embed/src/lite-yt-embed.css';
 import urlMatcher from './matcher';
+import { getImage } from 'astro:assets';
 
 export interface Props extends astroHTML.JSX.HTMLAttributes {
 	id: string;
@@ -8,6 +9,7 @@ export interface Props extends astroHTML.JSX.HTMLAttributes {
 	posterQuality?: 'max' | 'high' | 'default' | 'low';
 	params?: string;
 	playlabel?: string;
+	downloadPoster?: boolean;
 }
 
 const {
@@ -15,6 +17,7 @@ const {
 	poster,
 	posterQuality = 'default',
 	title,
+	downloadPoster,
 	...attrs
 } = Astro.props as Props;
 
@@ -35,6 +38,9 @@ const posterFile =
 	}[posterQuality] || 'hqdefault';
 const posterURL =
 	poster || `https://i.ytimg.com/vi_webp/${videoid}/${posterFile}.webp`;
+const posterSource = downloadPoster
+	? (await getImage({ src: posterURL, inferSize: true, format: 'webp' })).src
+	: posterURL;
 const href = `https://youtube.com/watch?v=${videoid}`;
 ---
 
@@ -43,7 +49,7 @@ const href = `https://youtube.com/watch?v=${videoid}`;
 	{title}
 	data-title={title}
 	{...attrs}
-	style={`background-image: url('${posterURL}');`}
+	style={`background-image: url('${posterSource}');`}
 >
 	<a {href} class="lty-playbtn">
 		<span class="lyt-visually-hidden">{attrs.playlabel}</span>

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -38,9 +38,7 @@ const posterFile =
 	}[posterQuality] || 'hqdefault';
 const posterURL =
 	poster || `https://i.ytimg.com/vi_webp/${videoid}/${posterFile}.webp`;
-const posterSource = downloadPoster
-	? (await getImage({ src: posterURL, inferSize: true, format: 'webp' })).src
-	: posterURL;
+const posterSource = (await getImage({ src: posterURL, inferSize: true, format: 'webp' })).src
 const href = `https://youtube.com/watch?v=${videoid}`;
 ---
 


### PR DESCRIPTION
Add a `downloadPoster` prop to YouTube and Vimeo and LinkPreview components.
Download images at build time, using `getImage()`.