### PR TITLE
Add `posterFormat` prop to `<YouTube>`

### DIFF
--- a/.changeset/hot-ligers-cough.md
+++ b/.changeset/hot-ligers-cough.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-youtube': minor
+---
+
+Add `posterFormat` prop to `<YouTube>` to allow selecting between `jpg` and `webp` posters

--- a/.changeset/six-experts-rush.md
+++ b/.changeset/six-experts-rush.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-youtube': patch
+---
+
+Use `jpg` as default `posterFormat` for `<YouTube>`

--- a/docs/src/content/docs/components/youtube.mdx
+++ b/docs/src/content/docs/components/youtube.mdx
@@ -68,16 +68,16 @@ For example, this is the same video as above but with a custom poster image:
 ### `posterFormat`
 
 **Type:** `'jpg' | 'webp'`
-**Default:** `'webp'`
+**Default:** `'jpg'`
 
 When using the default YouTube poster image, set the `posterFormat` to change the format of the placeholder image.
-This can be useful if displaying older videos that do not have `webp` posters.
+This can be used to select the newer `webp` format which typically has a lower file size and removes the black bars.
 
 ```astro
-<YouTube id="TtRtkTzHVBU" posterFormat="jpg" />
+<YouTube id="TtRtkTzHVBU" posterFormat="webp" />
 ```
 
-<YouTube id="TtRtkTzHVBU" posterFormat="jpg" />
+<YouTube id="TtRtkTzHVBU" posterFormat="webp" />
 
 ### `posterQuality`
 

--- a/docs/src/content/docs/components/youtube.mdx
+++ b/docs/src/content/docs/components/youtube.mdx
@@ -65,6 +65,20 @@ For example, this is the same video as above but with a custom poster image:
 	poster="https://images-assets.nasa.gov/image/0302063/0302063~medium.jpg"
 />
 
+### `posterFormat`
+
+**Type:** `'jpg' | 'webp'`
+**Default:** `'webp'`
+
+When using the default YouTube poster image, set the `posterFormat` to change the format of the placeholder image.
+This can be useful if displaying older videos that do not have `webp` posters.
+
+```astro
+<YouTube id="TtRtkTzHVBU" posterFormat="jpg" />
+```
+
+<YouTube id="TtRtkTzHVBU" posterFormat="jpg" />
+
 ### `posterQuality`
 
 **Type:** `'max' | 'high' | 'default' | 'low'`  

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -14,7 +14,7 @@ export interface Props extends astroHTML.JSX.HTMLAttributes {
 const {
 	id,
 	poster,
-	posterFormat = 'webp',
+	posterFormat = 'jpg',
 	posterQuality = 'default',
 	title,
 	...attrs

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -5,6 +5,7 @@ import urlMatcher from './matcher';
 export interface Props extends astroHTML.JSX.HTMLAttributes {
 	id: string;
 	poster?: string;
+	posterFormat?: 'jpg' | 'webp';
 	posterQuality?: 'max' | 'high' | 'default' | 'low';
 	params?: string;
 	playlabel?: string;
@@ -13,6 +14,7 @@ export interface Props extends astroHTML.JSX.HTMLAttributes {
 const {
 	id,
 	poster,
+	posterFormat = 'webp',
 	posterQuality = 'default',
 	title,
 	...attrs
@@ -34,7 +36,11 @@ const posterFile =
 		low: 'default',
 	}[posterQuality] || 'hqdefault';
 const posterURL =
-	poster || `https://i.ytimg.com/vi_webp/${videoid}/${posterFile}.webp`;
+	poster ||
+	{
+		jpg: `https://i.ytimg.com/vi/${videoid}/${posterFile}.jpg`,
+		webp: `https://i.ytimg.com/vi_webp/${videoid}/${posterFile}.webp`,
+	}[posterFormat];
 const href = `https://youtube.com/watch?v=${videoid}`;
 ---
 

--- a/tests/astro-embed-youtube.mjs
+++ b/tests/astro-embed-youtube.mjs
@@ -88,6 +88,32 @@ test('it can render a lower resolution poster image', async () => {
 	);
 });
 
+test('it can render a jpg poster image', async () => {
+	const { window } = await renderDOM(
+		'./packages/astro-embed-youtube/YouTube.astro',
+		{ id: videoid, posterFormat: 'jpg' }
+	);
+	const embed = window.document.querySelector('lite-youtube');
+	assert.ok(embed);
+	assert.is(
+		embed.style['background-image'],
+		`url('https://i.ytimg.com/vi/${videoid}/hqdefault.jpg')`
+	);
+});
+
+test('it can render a lower resolution jpg poster image', async () => {
+	const { window } = await renderDOM(
+		'./packages/astro-embed-youtube/YouTube.astro',
+		{ id: videoid, posterFormat: 'jpg', posterQuality: 'low' }
+	);
+	const embed = window.document.querySelector('lite-youtube');
+	assert.ok(embed);
+	assert.is(
+		embed.style['background-image'],
+		`url('https://i.ytimg.com/vi/${videoid}/default.jpg')`
+	);
+});
+
 test('title attribute also sets `data-title`', async () => {
 	const { window } = await renderDOM(
 		'./packages/astro-embed-youtube/YouTube.astro',

--- a/tests/astro-embed-youtube.mjs
+++ b/tests/astro-embed-youtube.mjs
@@ -13,7 +13,7 @@ test('it should render a lite-youtube element', async () => {
 	assert.ok(embed);
 	assert.is(
 		embed.style['background-image'],
-		`url('https://i.ytimg.com/vi_webp/${videoid}/hqdefault.webp')`
+		`url('https://i.ytimg.com/vi/${videoid}/hqdefault.jpg')`
 	);
 	// It renders a static link to the video.
 	const playButton = /** @type {HTMLAnchorElement} */ (
@@ -84,33 +84,33 @@ test('it can render a lower resolution poster image', async () => {
 	assert.ok(embed);
 	assert.is(
 		embed.style['background-image'],
-		`url('https://i.ytimg.com/vi_webp/${videoid}/default.webp')`
-	);
-});
-
-test('it can render a jpg poster image', async () => {
-	const { window } = await renderDOM(
-		'./packages/astro-embed-youtube/YouTube.astro',
-		{ id: videoid, posterFormat: 'jpg' }
-	);
-	const embed = window.document.querySelector('lite-youtube');
-	assert.ok(embed);
-	assert.is(
-		embed.style['background-image'],
-		`url('https://i.ytimg.com/vi/${videoid}/hqdefault.jpg')`
-	);
-});
-
-test('it can render a lower resolution jpg poster image', async () => {
-	const { window } = await renderDOM(
-		'./packages/astro-embed-youtube/YouTube.astro',
-		{ id: videoid, posterFormat: 'jpg', posterQuality: 'low' }
-	);
-	const embed = window.document.querySelector('lite-youtube');
-	assert.ok(embed);
-	assert.is(
-		embed.style['background-image'],
 		`url('https://i.ytimg.com/vi/${videoid}/default.jpg')`
+	);
+});
+
+test('it can render a webp poster image', async () => {
+	const { window } = await renderDOM(
+		'./packages/astro-embed-youtube/YouTube.astro',
+		{ id: videoid, posterFormat: 'webp' }
+	);
+	const embed = window.document.querySelector('lite-youtube');
+	assert.ok(embed);
+	assert.is(
+		embed.style['background-image'],
+		`url('https://i.ytimg.com/vi_webp/${videoid}/hqdefault.webp')`
+	);
+});
+
+test('it can render a lower resolution webp poster image', async () => {
+	const { window } = await renderDOM(
+		'./packages/astro-embed-youtube/YouTube.astro',
+		{ id: videoid, posterFormat: 'webp', posterQuality: 'low' }
+	);
+	const embed = window.document.querySelector('lite-youtube');
+	assert.ok(embed);
+	assert.is(
+		embed.style['background-image'],
+		`url('https://i.ytimg.com/vi_webp/${videoid}/default.webp')`
 	);
 });
 


### PR DESCRIPTION
- Add `posterFormat` prop to `<YouTube>` to allow selecting between `jpg` and `webp` posters
  - Not all videos have `webp` posters