### PR TITLE
Only match URLs that don’t have a custom label

### DIFF
--- a/.changeset/large-dolls-burn.md
+++ b/.changeset/large-dolls-burn.md
@@ -1,0 +1,7 @@
+---
+'@astro-community/astro-embed-integration': patch
+---
+
+Fixes an issue where the integration would match links that take up an entire paragraph even if they included a custom link.
+
+For example, `[Check it out!](https://example.com)` would be converted to a `<LinkPreview>` component instead of rendering an `<a>` tag. This is now fixed and only plain URLs like `https://example.com` will match.

--- a/packages/astro-embed-integration/remark-plugin.ts
+++ b/packages/astro-embed-integration/remark-plugin.ts
@@ -58,9 +58,22 @@ export default function createPlugin({
 			const link: Link | null = select(':scope > link:only-child', paragraph);
 			if (!link) return;
 
-			const { url } = link;
+			const { url, children } = link;
 			// We’re only interested in HTTP links
-			if (!url?.startsWith('http')) return;
+			if (!url || !url.startsWith('http')) return;
+			// URLs should have a single child
+			if (!children || children.length !== 1) return;
+
+			// The child should be a text node with a value matching the URL
+			const child = children[0];
+			if (
+				!child ||
+				child.type !== 'text' ||
+				!('value' in child) ||
+				child.value !== url
+			) {
+				return;
+			}
 
 			const component = getComponent(url);
 			if (component) {

--- a/packages/astro-embed-integration/remark-plugin.ts
+++ b/packages/astro-embed-integration/remark-plugin.ts
@@ -1,4 +1,4 @@
-import { Node, select, selectAll } from 'unist-util-select';
+import { type Node, select, selectAll } from 'unist-util-select';
 import twitterMatcher from '@astro-community/astro-embed-twitter/matcher';
 import vimeoMatcher from '@astro-community/astro-embed-vimeo/matcher';
 import youtubeMatcher from '@astro-community/astro-embed-youtube/matcher';


### PR DESCRIPTION
Closes #120 

Fixes an issue where the integration would match links that take up an entire paragraph even if they included a custom link.

For example, `[Check it out!](https://example.com)` would be converted to a `<LinkPreview>` component instead of rendering an `<a>` tag. This is now fixed and only plain URLs like `https://example.com` will match.
