### PR TITLE
fix build error when using with cloudflare adapter

### DIFF
--- a/.changeset/beige-llamas-visit.md
+++ b/.changeset/beige-llamas-visit.md
@@ -1,0 +1,5 @@
+---
+"@astro-community/astro-embed-utils": patch
+---
+
+Fixes support for serverless usage, for example with the Cloudflare adapter.

--- a/packages/astro-embed-utils/index.ts
+++ b/packages/astro-embed-utils/index.ts
@@ -1,4 +1,4 @@
-import { parseHTML } from 'linkedom';
+import { parseHTML } from 'linkedom/worker';
 
 class LRU<K, V> extends Map<K, V> {
 	constructor(private readonly maxSize: number) {


### PR DESCRIPTION
This pr closes #124
This pr changes the import from `linkedom` to `linkedom/worker` which enables it to work with other javascript runtimes as well.