### PR TITLE
Add `hideMedia` prop to `LinkPreview`

### DIFF
--- a/.changeset/shaggy-experts-hammer.md
+++ b/.changeset/shaggy-experts-hammer.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-link-preview': patch
+---
+
+Add `showImage` and `showVideo` props to `LinkPreview`

--- a/.changeset/shaggy-experts-hammer.md
+++ b/.changeset/shaggy-experts-hammer.md
@@ -2,4 +2,4 @@
 '@astro-community/astro-embed-link-preview': patch
 ---
 
-Add `showImage` and `showVideo` props to `LinkPreview`
+Add `hideMedia` prop to `LinkPreview`

--- a/docs/src/content/docs/components/link-preview.mdx
+++ b/docs/src/content/docs/components/link-preview.mdx
@@ -46,6 +46,21 @@ The above code produces the following result:
 
 <LinkPreview id="https://fosstodon.org/@mikeneu/112123823339364565" />
 
+
+### Hiding media
+
+If a URL's image or video is unwanted, add `hideMedia` as a prop.
+
+
+```astro
+<LinkPreview id="https://fosstodon.org/@mikeneu/112123823339364565" hideMedia />
+```
+
+The above code produces the following result:
+
+<LinkPreview id="https://fosstodon.org/@mikeneu/112123823339364565" hideMedia/>
+
+
 ### Limitations
 
 The available Open Graph metadata varies from site to site.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12988,7 +12988,7 @@
     },
     "packages/astro-embed-utils": {
       "name": "@astro-community/astro-embed-utils",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "linkedom": "^0.14.26"

--- a/packages/astro-embed-link-preview/LinkPreview.astro
+++ b/packages/astro-embed-link-preview/LinkPreview.astro
@@ -5,12 +5,10 @@ export interface Props {
 	/** URL to fetch Open Graph data. */
 	id: string;
 	/** Whether to show the video if supplied in OpenGraph */
-	showVideo?: boolean;
-	/** Whether to show the image if supplied in OpenGraph */
-	showImage?: boolean;
+	hideMedia?: boolean;
 }
 
-const { id, showVideo = true, showImage = true } = Astro.props as Props;
+const { id, hideMedia = false } = Astro.props as Props;
 
 const meta = await parseOpenGraph(id);
 const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
@@ -22,11 +20,9 @@ const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
 			class:list={[
 				'link-preview',
 				{
-					'link-preview--has-video': showVideo && meta.video && meta.videoType,
-					'link-preview--no-media': !(
-						(showVideo && meta.video && meta.videoType) ||
-						(showImage && meta.image)
-					),
+					'link-preview--has-video': !hideMedia && meta.video && meta.videoType,
+					'link-preview--no-media':
+						hideMedia || !((meta.video && meta.videoType) || meta.image),
 				},
 			]}
 		>
@@ -39,11 +35,11 @@ const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
 				</header>
 				<small class="link-preview__description">{meta.description}</small>
 			</div>
-			{showVideo && meta.video && meta.videoType ? (
+			{!hideMedia && meta.video && meta.videoType ? (
 				<video controls preload="metadata" width="1200" height="630">
 					<source src={meta.video} type={meta.videoType} />
 				</video>
-			) : showImage && meta.image ? (
+			) : !hideMedia && meta.image ? (
 				<img
 					src={meta.image}
 					alt={meta.imageAlt || ''}

--- a/packages/astro-embed-link-preview/LinkPreview.astro
+++ b/packages/astro-embed-link-preview/LinkPreview.astro
@@ -4,11 +4,11 @@ import { parseOpenGraph } from './lib';
 export interface Props {
 	/** URL to fetch Open Graph data. */
 	id: string;
-	/** Whether to show the video if supplied in OpenGraph */
+	/** Hide any image or video even if set in the OpenGraph data. */
 	hideMedia?: boolean;
 }
 
-const { id, hideMedia = false } = Astro.props as Props;
+const { id, hideMedia = false } = Astro.props;
 
 const meta = await parseOpenGraph(id);
 const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
@@ -35,11 +35,11 @@ const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
 				</header>
 				<small class="link-preview__description">{meta.description}</small>
 			</div>
-			{!hideMedia && meta.video && meta.videoType ? (
+			{hideMedia ? null : meta.video && meta.videoType ? (
 				<video controls preload="metadata" width="1200" height="630">
 					<source src={meta.video} type={meta.videoType} />
 				</video>
-			) : !hideMedia && meta.image ? (
+			) : meta.image ? (
 				<img
 					src={meta.image}
 					alt={meta.imageAlt || ''}

--- a/packages/astro-embed-link-preview/LinkPreview.astro
+++ b/packages/astro-embed-link-preview/LinkPreview.astro
@@ -4,9 +4,13 @@ import { parseOpenGraph } from './lib';
 export interface Props {
 	/** URL to fetch Open Graph data. */
 	id: string;
+	/** Whether to show the video if supplied in OpenGraph */
+	showVideo?: boolean;
+	/** Whether to show the image if supplied in OpenGraph */
+	showImage?: boolean;
 }
 
-const { id } = Astro.props;
+const { id, showVideo = true, showImage = true } = Astro.props as Props;
 
 const meta = await parseOpenGraph(id);
 const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
@@ -18,10 +22,10 @@ const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
 			class:list={[
 				'link-preview',
 				{
-					'link-preview--has-video': meta.video && meta.videoType,
+					'link-preview--has-video': showVideo && meta.video && meta.videoType,
 					'link-preview--no-media': !(
-						(meta.video && meta.videoType) ||
-						meta.image
+						(showVideo && meta.video && meta.videoType) ||
+						(showImage && meta.image)
 					),
 				},
 			]}
@@ -35,20 +39,18 @@ const domain = meta?.url ? new URL(meta.url).hostname.replace('www.', '') : '';
 				</header>
 				<small class="link-preview__description">{meta.description}</small>
 			</div>
-			{meta.video && meta.videoType ? (
+			{showVideo && meta.video && meta.videoType ? (
 				<video controls preload="metadata" width="1200" height="630">
 					<source src={meta.video} type={meta.videoType} />
 				</video>
-			) : (
-				meta.image && (
-					<img
-						src={meta.image}
-						alt={meta.imageAlt || ''}
-						width="1200"
-						height="630"
-					/>
-				)
-			)}
+			) : showImage && meta.image ? (
+				<img
+					src={meta.image}
+					alt={meta.imageAlt || ''}
+					width="1200"
+					height="630"
+				/>
+			) : null}
 		</article>
 	) : (
 		<div class="link-preview link-preview--no-metadata">


### PR DESCRIPTION
Fixes https://github.com/delucis/astro-embed/issues/129

Tried to be minimally invasive in my edits and add `showImage` and `showVideo` props which should function as if the OG url didn't have an image or video, essentially.