### PR TITLE
Update `lite-youtube-embed` to v0.3.3

### DIFF
--- a/.changeset/swift-horses-walk.md
+++ b/.changeset/swift-horses-walk.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-youtube': patch
+---
+
+Fixes accessibility of play button in YouTube embed by upgrading `lite-youtube-embed`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7792,9 +7792,9 @@
       }
     },
     "node_modules/lite-youtube-embed": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.2.tgz",
-      "integrity": "sha512-b1dgKyF4PHhinonmr3PB172Nj0qQgA/7DE9EmeIXHR1ksnFEC2olWjNJyJGdsN2cleKHRjjsmrziKlwXtPlmLQ=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.3.tgz",
+      "integrity": "sha512-gFfVVnj6NRjxVfJKo3qoLtpi0v5mn3AcR4eKD45wrxQuxzveFJUb+7Cr6uV6n+DjO8X3p0UzPPquhGt0H/y+NA=="
     },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
@@ -12969,7 +12969,7 @@
     },
     "packages/astro-embed-link-preview": {
       "name": "@astro-community/astro-embed-link-preview",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@astro-community/astro-embed-utils": "^0.1.1"
@@ -13010,7 +13010,7 @@
       "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
-        "lite-youtube-embed": "^0.3.2"
+        "lite-youtube-embed": "^0.3.3"
       },
       "peerDependencies": {
         "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"

--- a/packages/astro-embed-youtube/package.json
+++ b/packages/astro-embed-youtube/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://astro-embed.netlify.app/components/youtube/",
   "dependencies": {
-    "lite-youtube-embed": "^0.3.2"
+    "lite-youtube-embed": "^0.3.3"
   },
   "peerDependencies": {
     "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"


### PR DESCRIPTION
Fixes #116 

Upgrades to https://github.com/paulirish/lite-youtube-embed/releases/tag/v0.3.3 in the `<YouTube>` component to fix accessibility issues with the play button.