### PR TITLE
Fix invalid Vimeo links

### DIFF
--- a/.changeset/cuddly-bears-smell.md
+++ b/.changeset/cuddly-bears-smell.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-vimeo': patch
+---
+
+Fix issue with invalid Vimeo links causing build errors

--- a/packages/astro-embed-vimeo/Vimeo.astro
+++ b/packages/astro-embed-vimeo/Vimeo.astro
@@ -37,13 +37,15 @@ const videoid = extractID(id);
 let posterURL = poster;
 if (!posterURL) {
 	const data = await safeGet(`https://vimeo.com/api/v2/video/${videoid}.json`);
-	const resolution =
-		{ max: 1280, high: 640, default: 480, low: 120 }[posterQuality] || 480;
-	const { thumbnail_large } = data?.[0] || {};
-	if (thumbnail_large.endsWith('d_640')) {
-		posterURL = thumbnail_large.slice(0, -3) + resolution;
-	} else {
-		posterURL = thumbnail_large;
+	if (data) {		
+		const resolution =
+			{ max: 1280, high: 640, default: 480, low: 120 }[posterQuality] || 480;
+		const { thumbnail_large } = data?.[0] || {};
+		if (thumbnail_large.endsWith('d_640')) {
+			posterURL = thumbnail_large.slice(0, -3) + resolution;
+		} else {
+			posterURL = thumbnail_large;
+		}
 	}
 }
 


### PR DESCRIPTION
Closes: https://github.com/delucis/astro-embed/issues/135

Fixes an issue with invalid Vimeo links throwing builds:

![image](https://github.com/user-attachments/assets/382b929a-865c-419e-b7c8-e45e55a2e1c4)

I tested this locally, I am not sure how to add a test for this since it is a private video link