### PR TITLE
Allows astro-embed to be installed in projects developed with Astro v5

### DIFF
--- a/.changeset/twenty-shoes-stare.md
+++ b/.changeset/twenty-shoes-stare.md
@@ -1,0 +1,9 @@
+---
+"@astro-community/astro-embed-integration": patch
+"@astro-community/astro-embed-twitter": patch
+"@astro-community/astro-embed-vimeo": patch
+"@astro-community/astro-embed-youtube": patch
+"astro-embed": patch
+---
+
+Adds support for Astro v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -3338,7 +3338,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
       }
     },
     "node_modules/astro-auto-import/node_modules/@types/node": {
@@ -12942,7 +12942,7 @@
         "@astro-community/astro-embed-youtube": "^0.5.0"
       },
       "peerDependencies": {
-        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
       }
     },
     "packages/astro-embed-integration": {
@@ -12959,7 +12959,7 @@
         "unist-util-select": "^4.0.1"
       },
       "peerDependencies": {
-        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
       }
     },
     "packages/astro-embed-integration/node_modules/@types/unist": {
@@ -12983,7 +12983,7 @@
         "@astro-community/astro-embed-utils": "^0.1.0"
       },
       "peerDependencies": {
-        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
       }
     },
     "packages/astro-embed-utils": {
@@ -13002,7 +13002,7 @@
         "@astro-community/astro-embed-utils": "^0.1.2"
       },
       "peerDependencies": {
-        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
       }
     },
     "packages/astro-embed-youtube": {
@@ -13013,7 +13013,7 @@
         "lite-youtube-embed": "^0.3.3"
       },
       "peerDependencies": {
-        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
       }
     }
   }

--- a/packages/astro-embed-integration/package.json
+++ b/packages/astro-embed-integration/package.json
@@ -31,6 +31,6 @@
     "unist-util-select": "^4.0.1"
   },
   "peerDependencies": {
-    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
   }
 }

--- a/packages/astro-embed-twitter/package.json
+++ b/packages/astro-embed-twitter/package.json
@@ -34,6 +34,6 @@
     "@astro-community/astro-embed-utils": "^0.1.0"
   },
   "peerDependencies": {
-    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
   }
 }

--- a/packages/astro-embed-vimeo/package.json
+++ b/packages/astro-embed-vimeo/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://astro-embed.netlify.app/components/vimeo/",
   "peerDependencies": {
-    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
   },
   "dependencies": {
     "@astro-community/astro-embed-utils": "^0.1.2"

--- a/packages/astro-embed-youtube/package.json
+++ b/packages/astro-embed-youtube/package.json
@@ -33,6 +33,6 @@
     "lite-youtube-embed": "^0.3.3"
   },
   "peerDependencies": {
-    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
   }
 }

--- a/packages/astro-embed/package.json
+++ b/packages/astro-embed/package.json
@@ -38,6 +38,6 @@
     "@astro-community/astro-embed-youtube": "^0.5.0"
   },
   "peerDependencies": {
-    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
   }
 }


### PR DESCRIPTION
- Add `^5.0.0-beta` to `package.json` and `package-lock.json`.

Allows `astro-embed` to be installed in projects developed with **Astro v5**