### PR TITLE
update twitter url matching (x.com)

### DIFF
--- a/.changeset/proud-waves-jog.md
+++ b/.changeset/proud-waves-jog.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-twitter': patch
+---
+
+Fixes support for newer `x.com` URLs

--- a/demo/src/pages/twitter.astro
+++ b/demo/src/pages/twitter.astro
@@ -17,6 +17,11 @@ import Base from '../layouts/Base.astro';
 	<Component.Tweet
 		id="https://twitter.com/astrodotbuild/status/1402352777020395521"
 	/>
+
+	<h2>With x.com URLs</h2>
+	<Component.Tweet
+		id="https://x.com/astrodotbuild/status/1851286331491578330"
+	/>
 </Base>
 
 <style>

--- a/packages/astro-embed-twitter/matcher.ts
+++ b/packages/astro-embed-twitter/matcher.ts
@@ -1,7 +1,7 @@
 // Thanks to eleventy-plugin-embed-twitter
 // https://github.com/gfscott/eleventy-plugin-embed-twitter/blob/main/lib/extractMatch.js
 const urlPattern =
-	/(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:)??(?:\/\/)??(?:w{3}\.)??(?:twitter\.com)\/([a-zA-Z0-9_]{1,15})?(?:\/(?:status)\/)(\d+)?(?:[^\s<>]*)(?=(\s*))\5(?:<\/a>)??(?=(\s*))\6/;
+	/(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:)??(?:\/\/)??(?:w{3}\.)??(?:twitter\.com|x\.com)\/([a-zA-Z0-9_]{1,15})?(?:\/(?:status)\/)(\d+)?(?:[^\s<>]*)(?=(\s*))\5(?:<\/a>)??(?=(\s*))\6/;
 
 /**
  * Return a Tweet URL from a URL if it matches the pattern.

--- a/tests/astro-embed-twitter.mjs
+++ b/tests/astro-embed-twitter.mjs
@@ -28,4 +28,17 @@ test('it does not crash when we have undefined entities', async () => {
 	screen.getByText('December 7, 2022');
 });
 
+test('it works with x.com URLs', async () => {
+	const screen = await renderScreen(
+		'./packages/astro-embed-twitter/Tweet.astro',
+		{ id: 'https://x.com/astrodotbuild/status/1851286331491578330' }
+	);
+	screen.getByText(/⚠️ Be sure to check your kid's candy this year! ⚠️/);
+	screen.getByText(
+		/Just found a bloated 5.8 MB JavaScript bundle in this Reese's! 😱/
+	);
+	screen.getByText(/@astrodotbuild/);
+	screen.getByText('October 29, 2024');
+});
+
 test.run();


### PR DESCRIPTION
twitter changed their domain from `twitter.com` to `x.com` so the auto-embedder doesn't work for links with the new domain, I adjusted the regex to work with `x.com` too