### PR TITLE
fix wrapping of icons in `BaselineStatus`

### DIFF
--- a/.changeset/eleven-ghosts-confess.md
+++ b/.changeset/eleven-ghosts-confess.md
@@ -1,0 +1,5 @@
+---
+"@astro-community/astro-embed-baseline-status": patch
+---
+
+Removes `max-width` from `::part(browsers)` to prevent undesirable wrapping of browser icons.

--- a/packages/astro-embed-baseline-status/BaselineStatus.astro
+++ b/packages/astro-embed-baseline-status/BaselineStatus.astro
@@ -348,7 +348,6 @@ const year =
 
 	.baseline-status::part(browsers) {
 		font-size: 0;
-		max-width: 12.5rem;
 		display: flex;
 		flex-wrap: wrap;
 		gap: 1rem;


### PR DESCRIPTION
I noticed that the browser icons start wrapping in an undesired way, because of the `max-width`.

<img width="736" alt="" src="https://github.com/user-attachments/assets/fba31295-7c22-4bae-9b0f-2ea34a016c7a">

So I removed the `max-width`.

<img width="730" alt="" src="https://github.com/user-attachments/assets/2fa2376b-49c7-4ead-8445-e8a7231b4adf">

