### PR TITLE
Fix accessible names for embed youtube link

### DIFF
--- a/.changeset/sixty-oranges-sneeze.md
+++ b/.changeset/sixty-oranges-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@astro-community/astro-embed-youtube": patch
+---
+
+Fixes missing accessible name for `<YouTube>` component play button

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -45,8 +45,8 @@ const href = `https://youtube.com/watch?v=${videoid}`;
 	{...attrs}
 	style={`background-image: url('${posterURL}');`}
 >
-	<a {href} class="lty-playbtn" role="link" aria-label={title}>
-		<span class="lyt-visually-hidden">{attrs.playlabel}</span>
+	<a {href} class="lty-playbtn">
+		<span class="lyt-visually-hidden">{attrs.playlabel || 'Play'}</span>
 	</a>
 </lite-youtube>
 

--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -45,7 +45,7 @@ const href = `https://youtube.com/watch?v=${videoid}`;
 	{...attrs}
 	style={`background-image: url('${posterURL}');`}
 >
-	<a {href} class="lty-playbtn">
+	<a {href} class="lty-playbtn" role="link" aria-label={title}>
 		<span class="lyt-visually-hidden">{attrs.playlabel}</span>
 	</a>
 </lite-youtube>

--- a/tests/astro-embed-youtube.mjs
+++ b/tests/astro-embed-youtube.mjs
@@ -21,6 +21,7 @@ test('it should render a lite-youtube element', async () => {
 	);
 	assert.ok(playButton);
 	assert.is(playButton.href, `https://youtube.com/watch?v=${videoid}`);
+	assert.is(playButton.textContent?.trim(), 'Play');
 });
 
 test('it parses a youtube.com URL', async () => {


### PR DESCRIPTION
ARIA commands must have an accessible name, read more: https://dequeuniversity.com/rules/axe/4.10/aria-command-name

Otherwise i'm getting this issue in lighthouse Accessibility report:

![image](https://github.com/user-attachments/assets/01ea3934-b94d-4be7-8d6b-372d03431c5d)