### PR TITLE
fix: allow PostView to be passed to embed

### DIFF
--- a/.changeset/shaggy-ties-laugh.md
+++ b/.changeset/shaggy-ties-laugh.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-bluesky': patch
+---
+
+Allow PostView to be passed to embed

--- a/package-lock.json
+++ b/package-lock.json
@@ -12726,7 +12726,7 @@
     },
     "packages/astro-embed-bluesky": {
       "name": "@astro-community/astro-embed-bluesky",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@atproto/api": "^0.13.14",

--- a/packages/astro-embed-bluesky/src/index.ts
+++ b/packages/astro-embed-bluesky/src/index.ts
@@ -1,1 +1,2 @@
 export { default as BlueskyPost } from './post.astro';
+export type { Post } from './types';

--- a/packages/astro-embed-bluesky/src/post.astro
+++ b/packages/astro-embed-bluesky/src/post.astro
@@ -4,10 +4,11 @@ import Embed from './embed.astro';
 import type { Post } from './types';
 import './styles.css';
 import Avatar from './avatar.astro';
+import type { AppBskyFeedDefs } from '@atproto/api';
 
 type Props = {
 	id?: string;
-	post?: string | Post;
+	post?: string | Post | AppBskyFeedDefs.PostView;
 };
 
 const postRef = Astro.props.id ?? Astro.props.post;


### PR DESCRIPTION
Allow an ATProto `PostView` to be passed to the BlueSky embed. It currently only accepts our extended interface, which isn't needed. Thanks @brob for spotting it