### PR TITLE
fix: Bluesky embed hashtag links broken

### DIFF
--- a/.changeset/clean-falcons-remain.md
+++ b/.changeset/clean-falcons-remain.md
@@ -1,0 +1,5 @@
+---
+"@astro-community/astro-embed-bluesky": patch
+---
+
+Fixes hashtag links in Bluesky embeds

--- a/packages/astro-embed-bluesky/src/utils.ts
+++ b/packages/astro-embed-bluesky/src/utils.ts
@@ -37,7 +37,7 @@ export function renderPostAsHtml(post?: AppBskyFeedDefs.PostView | Post) {
 				segment.mention?.did
 			)}">${escapeHTML(segment.text)}</a>`;
 		} else if (segment.isTag()) {
-			html += `<a href="https://bsky.app/hastag/${escapeHTML(
+			html += `<a href="https://bsky.app/hashtag/${escapeHTML(
 				segment.tag?.tag
 			)}">#${escapeHTML(segment.tag?.tag)}</a>`;
 		} else {


### PR DESCRIPTION
I noticed hashtag links on Bluesky embeds were broken while playing around with the widget, just due to a minor typo in the URL composition.

- Correct typo `/hastag` → `/hashtag`