### PR TITLE
fix: Add missing dependency of astro-embed-bluesky to integration

### DIFF
--- a/.changeset/tough-pigs-exercise.md
+++ b/.changeset/tough-pigs-exercise.md
@@ -1,0 +1,5 @@
+---
+'@astro-community/astro-embed-integration': patch
+---
+
+fix: Add missing dependency to astro-embed-bluesky

--- a/package-lock.json
+++ b/package-lock.json
@@ -12726,7 +12726,7 @@
     },
     "packages/astro-embed-bluesky": {
       "name": "@astro-community/astro-embed-bluesky",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@atproto/api": "^0.13.14",
@@ -12741,6 +12741,7 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
+        "@astro-community/astro-embed-bluesky": "^0.1.3",
         "@astro-community/astro-embed-link-preview": "^0.2.0",
         "@astro-community/astro-embed-twitter": "^0.5.5",
         "@astro-community/astro-embed-vimeo": "^0.3.9",

--- a/packages/astro-embed-integration/package.json
+++ b/packages/astro-embed-integration/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://astro-embed.netlify.app/integration",
   "dependencies": {
+    "@astro-community/astro-embed-bluesky": "^0.1.3",
     "@astro-community/astro-embed-link-preview": "^0.2.0",
     "@astro-community/astro-embed-twitter": "^0.5.5",
     "@astro-community/astro-embed-vimeo": "^0.3.9",


### PR DESCRIPTION
Hi :wave:,

I noticed in a project that uses pnpm workspaces with hoisting disabled that `astro-embed-integration` is missing the dependency on `astro-embed-bluesky`. This PR adds it to the dependencies, so it can be resolved correctly.

I tried to follow the conventions, let me know if I should change anything.