### PR TITLE
Add YouTube style prop, following example from Vimeo

### DIFF
--- a/packages/astro-embed-youtube/YouTube.astro
+++ b/packages/astro-embed-youtube/YouTube.astro
@@ -15,6 +15,7 @@ const {
 	poster,
 	posterQuality = 'default',
 	title,
+	style,
 	...attrs
 } = Astro.props as Props;
 
@@ -36,6 +37,10 @@ const posterFile =
 const posterURL =
 	poster || `https://i.ytimg.com/vi/${videoid}/${posterFile}.jpg`;
 const href = `https://youtube.com/watch?v=${videoid}`;
+
+const styles = [];
+if (style) styles.push(style);
+if (posterURL) styles.push(`background-image: url('${posterURL}')`);
 ---
 
 <lite-youtube
@@ -43,7 +48,7 @@ const href = `https://youtube.com/watch?v=${videoid}`;
 	{title}
 	data-title={title}
 	{...attrs}
-	style={`background-image: url('${posterURL}');`}
+	style={styles.join(';')}
 >
 	<a {href} class="lty-playbtn">
 		<span class="lyt-visually-hidden">{attrs.playlabel || 'Play'}</span>

--- a/tests/astro-embed-youtube.mjs
+++ b/tests/astro-embed-youtube.mjs
@@ -89,6 +89,21 @@ test('it can render a lower resolution poster image', async () => {
 	);
 });
 
+test('it can append a custom style', async () => {
+	const style = 'width: 100%';
+	const { window } = await renderDOM(
+		'./packages/astro-embed-youtube/YouTube.astro',
+		{ id: videoid, style }
+	);
+	const embed = window.document.querySelector('lite-youtube');
+	assert.ok(embed);
+	assert.is(embed.style['width'], '100%');
+	assert.is(
+		embed.style['background-image'],
+		`url('https://i.ytimg.com/vi/${videoid}/hqdefault.jpg')`
+	);
+});
+
 test('title attribute also sets `data-title`', async () => {
 	const { window } = await renderDOM(
 		'./packages/astro-embed-youtube/YouTube.astro',


### PR DESCRIPTION
This PR adds support for custom inline styles to the YouTube embed component, matching the approach already taken in the Vimeo component.

I also added a test to confirm the new style(s) are appended, i.e. they do not overwrite the default `background-image` style.

In any case, thanks for writing this project!