### PR TITLE
Explicitly link workspace dependencies in docs package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "@astro-community/astro-embed-bluesky": "workspace:*",
     "@astro-community/astro-embed-link-preview": "workspace:*",
     "@astro-community/astro-embed-twitter": "workspace:*",
+    "@astro-community/astro-embed-vimeo": "workspace:*",
     "@astro-community/astro-embed-youtube": "workspace:*",
     "@astrojs/starlight": "^0.36.0",
     "astro": "^5.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@astro-community/astro-embed-twitter':
         specifier: workspace:*
         version: link:../packages/astro-embed-twitter
+      '@astro-community/astro-embed-vimeo':
+        specifier: workspace:*
+        version: link:../packages/astro-embed-vimeo
       '@astro-community/astro-embed-youtube':
         specifier: workspace:*
         version: link:../packages/astro-embed-youtube


### PR DESCRIPTION
Docs build is failing in #217 so seeing if this helps.