### PR TITLE
Bump the integration and main package as minors for Bluesky update

### DIFF
--- a/.changeset/afraid-years-marry.md
+++ b/.changeset/afraid-years-marry.md
@@ -1,7 +1,9 @@
 ---
 '@astro-community/astro-embed-bluesky': minor
+'@astro-community/astro-embed-integration': minor
+'astro-embed': minor
 ---
 
-Reduces install size by ~60%
+Reduces install size of `@astro-community/astro-embed-bluesky` by ~60%
 
 The `<Bluesky>` component now uses [atcute](https://github.com/mary-ext/atcute) instead of `@atproto/api` internally. Because of this, the `Post` TypeScript type has changed slightly. If you were passing Bluesky data directly to the component (instead of a post URL), it should still work, but in some circumstances you may see type errors and need to adjust things slightly. [Let us know if you run into issues upgrading](https://github.com/delucis/astro-embed/issues/new/choose).


### PR DESCRIPTION
Follow-up to #261 to make sure the other packages depending on the Bluesky component also get a minor bump, not a major.