### PR TITLE
Fix integration runtime exports

### DIFF
--- a/.changeset/clean-integration-entrypoints.md
+++ b/.changeset/clean-integration-entrypoints.md
@@ -1,0 +1,12 @@
+---
+"@astro-community/astro-embed-integration": patch
+"@astro-community/astro-embed-bluesky": patch
+"@astro-community/astro-embed-gist": patch
+"@astro-community/astro-embed-link-preview": patch
+"@astro-community/astro-embed-mastodon": patch
+"@astro-community/astro-embed-twitter": patch
+"@astro-community/astro-embed-vimeo": patch
+"@astro-community/astro-embed-youtube": patch
+---
+
+Publish compiled JavaScript for the integration entrypoint and matcher subpath exports so Node does not load TypeScript files from node_modules.

--- a/demo/package.json
+++ b/demo/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "prebuild": "corepack pnpm --filter @astro-community/astro-embed-integration --filter @astro-community/astro-embed-bluesky --filter @astro-community/astro-embed-gist --filter @astro-community/astro-embed-link-preview --filter @astro-community/astro-embed-mastodon --filter @astro-community/astro-embed-twitter --filter @astro-community/astro-embed-vimeo --filter @astro-community/astro-embed-youtube prepack",
     "build": "astro build",
     "preview": "astro preview"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "prebuild": "corepack pnpm --filter @astro-community/astro-embed-integration --filter @astro-community/astro-embed-bluesky --filter @astro-community/astro-embed-gist --filter @astro-community/astro-embed-link-preview --filter @astro-community/astro-embed-mastodon --filter @astro-community/astro-embed-twitter --filter @astro-community/astro-embed-vimeo --filter @astro-community/astro-embed-youtube prepack",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/packages/astro-embed-bluesky/package.json
+++ b/packages/astro-embed-bluesky/package.json
@@ -3,12 +3,19 @@
   "version": "0.2.1",
   "description": "Component to embed a fully-styled Bluesky post with no client-side JavaScript in your Astro site",
   "type": "module",
+  "scripts": {
+    "prepack": "tsc -p tsconfig.build.json"
+  },
   "files": [
-    "src"
+    "src",
+    "dist"
   ],
   "exports": {
     ".": "./src/index.ts",
-    "./matcher": "./src/matcher.ts"
+    "./matcher": {
+      "types": "./dist/matcher.d.ts",
+      "default": "./dist/matcher.js"
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/astro-embed-bluesky/tsconfig.build.json
+++ b/packages/astro-embed-bluesky/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src/matcher.ts"]
+}

--- a/packages/astro-embed-gist/package.json
+++ b/packages/astro-embed-gist/package.json
@@ -3,13 +3,20 @@
   "version": "0.1.0",
   "description": "Component to easily embed GitHub Gists on your Astro site",
   "type": "module",
+  "scripts": {
+    "prepack": "tsc -p tsconfig.build.json"
+  },
   "exports": {
     ".": "./index.ts",
-    "./matcher": "./matcher.ts"
+    "./matcher": {
+      "types": "./dist/matcher.d.ts",
+      "default": "./dist/matcher.js"
+    }
   },
   "files": [
     "index.ts",
     "matcher.ts",
+    "dist",
     "Gist.astro",
     "Gist.css"
   ],

--- a/packages/astro-embed-gist/tsconfig.build.json
+++ b/packages/astro-embed-gist/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["matcher.ts"]
+}

--- a/packages/astro-embed-integration/index.ts
+++ b/packages/astro-embed-integration/index.ts
@@ -1,5 +1,5 @@
 import type { AstroConfig, AstroIntegration } from 'astro';
-import createEmbedPlugin, { componentNames } from './remark-plugin';
+import createEmbedPlugin, { componentNames } from './remark-plugin.js';
 import AutoImport from 'astro-auto-import';
 const importNamespace = 'AuToImPoRtEdAstroEmbed';
 

--- a/packages/astro-embed-integration/package.json
+++ b/packages/astro-embed-integration/package.json
@@ -3,12 +3,17 @@
   "version": "0.12.0",
   "description": "Astro integration to automatically convert URLs in Markdown files to embeds",
   "type": "module",
+  "scripts": {
+    "prepack": "tsc -p tsconfig.build.json"
+  },
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "files": [
-    "index.ts",
-    "remark-plugin.ts"
+    "dist"
   ],
   "repository": {
     "type": "git",

--- a/packages/astro-embed-integration/tsconfig.build.json
+++ b/packages/astro-embed-integration/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["index.ts", "remark-plugin.ts"]
+}

--- a/packages/astro-embed-link-preview/package.json
+++ b/packages/astro-embed-link-preview/package.json
@@ -3,15 +3,22 @@
   "version": "0.3.1",
   "description": "Component to embed a website’s OpenGraph image and metadata on your Astro site",
   "type": "module",
+  "scripts": {
+    "prepack": "tsc -p tsconfig.build.json"
+  },
   "exports": {
     ".": "./index.ts",
-    "./matcher": "./matcher.ts"
+    "./matcher": {
+      "types": "./dist/matcher.d.ts",
+      "default": "./dist/matcher.js"
+    }
   },
   "files": [
     "dom.ts",
     "lib.ts",
     "index.ts",
     "matcher.ts",
+    "dist",
     "LinkPreview.astro"
   ],
   "repository": {

--- a/packages/astro-embed-link-preview/tsconfig.build.json
+++ b/packages/astro-embed-link-preview/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["matcher.ts"]
+}

--- a/packages/astro-embed-mastodon/package.json
+++ b/packages/astro-embed-mastodon/package.json
@@ -3,13 +3,20 @@
   "version": "0.1.1",
   "description": "Component to easily embed Mastodon posts on your Astro site",
   "type": "module",
+  "scripts": {
+    "prepack": "tsc -p tsconfig.build.json"
+  },
   "exports": {
     ".": "./index.ts",
-    "./matcher": "./matcher.ts"
+    "./matcher": {
+      "types": "./dist/matcher.d.ts",
+      "default": "./dist/matcher.js"
+    }
   },
   "files": [
     "index.ts",
     "matcher.ts",
+    "dist",
     "src"
   ],
   "repository": {

--- a/packages/astro-embed-mastodon/tsconfig.build.json
+++ b/packages/astro-embed-mastodon/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["matcher.ts"]
+}

--- a/packages/astro-embed-twitter/package.json
+++ b/packages/astro-embed-twitter/package.json
@@ -3,13 +3,20 @@
   "version": "0.5.11",
   "description": "Component to easily embed Tweets on your Astro site",
   "type": "module",
+  "scripts": {
+    "prepack": "tsc -p tsconfig.build.json"
+  },
   "exports": {
     ".": "./index.ts",
-    "./matcher": "./matcher.ts"
+    "./matcher": {
+      "types": "./dist/matcher.d.ts",
+      "default": "./dist/matcher.js"
+    }
   },
   "files": [
     "index.ts",
     "matcher.ts",
+    "dist",
     "Tweet.astro",
     "Tweet.css"
   ],

--- a/packages/astro-embed-twitter/tsconfig.build.json
+++ b/packages/astro-embed-twitter/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["matcher.ts"]
+}

--- a/packages/astro-embed-vimeo/package.json
+++ b/packages/astro-embed-vimeo/package.json
@@ -3,13 +3,20 @@
   "version": "0.3.12",
   "description": "Component to easily embed Vimeo videos on your Astro site",
   "type": "module",
+  "scripts": {
+    "prepack": "tsc -p tsconfig.build.json"
+  },
   "exports": {
     ".": "./index.ts",
-    "./matcher": "./matcher.ts"
+    "./matcher": {
+      "types": "./dist/matcher.d.ts",
+      "default": "./dist/matcher.js"
+    }
   },
   "files": [
     "index.ts",
     "matcher.ts",
+    "dist",
     "Vimeo.astro",
     "Vimeo.css"
   ],

--- a/packages/astro-embed-vimeo/tsconfig.build.json
+++ b/packages/astro-embed-vimeo/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["matcher.ts"]
+}

--- a/packages/astro-embed-youtube/package.json
+++ b/packages/astro-embed-youtube/package.json
@@ -3,13 +3,20 @@
   "version": "0.5.10",
   "description": "Component to easily embed YouTube videos on your Astro site",
   "type": "module",
+  "scripts": {
+    "prepack": "tsc -p tsconfig.build.json"
+  },
   "exports": {
     ".": "./index.ts",
-    "./matcher": "./matcher.ts"
+    "./matcher": {
+      "types": "./dist/matcher.d.ts",
+      "default": "./dist/matcher.js"
+    }
   },
   "files": [
     "index.ts",
     "matcher.ts",
+    "dist",
     "YouTube.astro"
   ],
   "repository": {

--- a/packages/astro-embed-youtube/tsconfig.build.json
+++ b/packages/astro-embed-youtube/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["matcher.ts"]
+}


### PR DESCRIPTION
## Summary

- publish compiled JavaScript for `@astro-community/astro-embed-integration` instead of exposing `index.ts` from the package root
- publish compiled JavaScript for the matcher subpath exports that the integration imports
- add package-level `prepack` build configs and a changeset for the affected packages

This keeps the existing component entrypoints untouched and focuses on the runtime path needed by the integration. In the current published packages, a clean Node import of `@astro-community/astro-embed-integration` fails with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` because Node tries to load TypeScript files from `node_modules`. After this change, the integration and matcher subpaths resolve to generated JS files.

## Testing

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter <affected-package> prepack` for all touched packages
- Packed the affected packages locally, installed the tarballs into a fresh temp project, and verified these imports all succeed:
  - `@astro-community/astro-embed-bluesky/matcher`
  - `@astro-community/astro-embed-gist/matcher`
  - `@astro-community/astro-embed-twitter/matcher`
  - `@astro-community/astro-embed-vimeo/matcher`
  - `@astro-community/astro-embed-youtube/matcher`
  - `@astro-community/astro-embed-mastodon/matcher`
  - `@astro-community/astro-embed-link-preview/matcher`
  - `@astro-community/astro-embed-integration`
- `corepack pnpm test`
- `corepack pnpm exec prettier -c` on the changed files

Note: `corepack pnpm lint` currently fails in this Windows checkout because ESLint/Prettier reports CRLF line endings across many existing files outside this change.